### PR TITLE
feat(markdown): add KaTeX math rendering (closes #1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "ioredis": "^5.10.1",
+    "katex": "^0.16.38",
     "marked": "^17.0.1",
     "motion": "^12.29.2",
     "playwright": "^1.58.2",
@@ -48,8 +49,10 @@
     "react-joyride": "^2.9.3",
     "react-markdown": "^10.1.0",
     "recharts": "^3.7.0",
+    "rehype-katex": "^7.0.1",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
     "shiki": "^3.21.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18",
@@ -109,6 +112,10 @@
     "url": "https://github.com/JPeetz/Hermes-Studio.git"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "unrs-resolver"]
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "unrs-resolver"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       ioredis:
         specifier: ^5.10.1
         version: 5.10.1
+      katex:
+        specifier: ^0.16.38
+        version: 0.16.38
       marked:
         specifier: ^17.0.1
         version: 17.0.4
@@ -92,12 +95,18 @@ importers:
       recharts:
         specifier: ^3.7.0
         version: 3.8.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@18.3.1)(react@19.2.4)(redux@5.0.1)
+      rehype-katex:
+        specifier: ^7.0.1
+        version: 7.0.1
       remark-breaks:
         specifier: ^4.0.0
         version: 4.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      remark-math:
+        specifier: ^6.0.0
+        version: 6.0.0
       shiki:
         specifier: ^3.21.0
         version: 3.23.0

--- a/src/components/prompt-kit/markdown.tsx
+++ b/src/components/prompt-kit/markdown.tsx
@@ -1,11 +1,14 @@
 import { marked } from 'marked'
 import { createContext, memo, useContext, useId, useMemo, useRef } from 'react'
 import ReactMarkdown from 'react-markdown'
+import rehypeKatex from 'rehype-katex'
 import remarkBreaks from 'remark-breaks'
 import remarkGfm from 'remark-gfm'
+import remarkMath from 'remark-math'
 import { CodeBlock } from './code-block'
 import type { Components } from 'react-markdown'
 import { cn } from '@/lib/utils'
+import 'katex/dist/katex.min.css'
 
 export type MarkdownProps = {
   children: string
@@ -309,7 +312,8 @@ const MemoizedMarkdownBlock = memo(
   }) {
     return (
       <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkBreaks]}
+        remarkPlugins={[remarkGfm, remarkBreaks, remarkMath]}
+        rehypePlugins={[rehypeKatex]}
         components={components}
       >
         {content}

--- a/src/test/prompt-kit/markdown-katex.test.tsx
+++ b/src/test/prompt-kit/markdown-katex.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { Markdown } from '@/components/prompt-kit/markdown'
+
+describe('Markdown + KaTeX', () => {
+  it('renders inline math with $...$ delimiters', () => {
+    const { container } = render(
+      <Markdown>{'The equation is $E = mc^2$ in physics.'}</Markdown>,
+    )
+    // remark-math + rehype-katex emits .katex spans
+    expect(container.querySelector('.katex')).toBeTruthy()
+  })
+
+  it('renders display math with $$...$$ delimiters as KaTeX', () => {
+    // NOTE: this component pre-tokenizes via marked.lexer() in
+    // parseMarkdownIntoBlocks before ReactMarkdown sees the content, which
+    // collapses `$$...$$` into a single paragraph token. remark-math + rehype-katex
+    // still parse and render the LaTeX (MathML output is correct), but the
+    // block-level `.katex-display` wrapper is not emitted. Follow-up slice can
+    // bypass the marked pre-split for math blocks. For MVP we only assert that
+    // the math renders at all and the MathML semantics are present.
+    const md = '$$\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}$$'
+    const { container } = render(<Markdown>{md}</Markdown>)
+    expect(container.querySelector('.katex')).toBeTruthy()
+    expect(container.querySelector('math')).toBeTruthy()
+    // Annotation tag confirms remark-math parsed the LaTeX, not just literal text
+    expect(container.querySelector('annotation[encoding="application/x-tex"]')).toBeTruthy()
+  })
+
+  it('treats escaped \\$ delimiters as literal text, not math', () => {
+    const { container } = render(<Markdown>{'Price is \\$10 per month.'}</Markdown>)
+    expect(container.querySelector('.katex')).toBeFalsy()
+    expect(container.textContent).toContain('Price is $10 per month.')
+  })
+
+  it('renders math mixed with markdown formatting (bold + inline code)', () => {
+    const md = '**Bold** equation $x^2$ and `code`.'
+    const { container } = render(<Markdown>{md}</Markdown>)
+    expect(container.querySelector('strong')).toBeTruthy()
+    expect(container.querySelector('code')).toBeTruthy()
+    expect(container.querySelector('.katex')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Closes #1.

Adds remark-math + rehype-katex to render `$...$` inline math and `$$...$$` display math in chat messages.

**Dependencies added (3):** `katex@^0.16.38`, `rehype-katex@^7.0.1`, `remark-math@^6.0.0`

**Files touched:**
- `src/components/prompt-kit/markdown.tsx` (+4 lines — imports + plugin chain)
- `src/test/prompt-kit/markdown-katex.test.tsx` (NEW, 4 vitest cases)

**Verification:**
- 4/4 KaTeX tests pass
- 194/194 full vitest suite green (17 files)
- `pnpm build` succeeds in 1.83s
- `pnpm exec tsc --noEmit` clean

**Known MVP tradeoff documented in the test file:** `parseMarkdownIntoBlocks` pre-tokenizes via `marked.lexer()` which doesn't understand math syntax, so `$$...$$` still renders as KaTeX (MathML semantics correct) but loses the `.katex-display` block-center wrapper. Follow-up slice can bypass the marked pre-split for math blocks if block-centered display is required.

Co-Authored-By: Claude Opus 4.7 (1M context)