### PR TITLE
fix: forward Hermes gateway bearer token and fix Conductor SSR crash

### DIFF
--- a/src/routes/api/hermes-jobs.ts
+++ b/src/routes/api/hermes-jobs.ts
@@ -4,6 +4,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
 import {
+  BEARER_TOKEN,
   HERMES_API,
   HERMES_UPGRADE_INSTRUCTIONS,
   ensureGatewayProbed,
@@ -34,7 +35,13 @@ export const Route = createFileRoute('/api/hermes-jobs')({
         const url = new URL(request.url)
         const params = url.searchParams.toString()
         const target = `${HERMES_API}/api/jobs${params ? `?${params}` : ''}`
-        const res = await fetch(target)
+        // The Hermes gateway requires a bearer token; forward it so the
+        // /api/jobs call doesn't bounce off a 401.
+        const res = await fetch(target, {
+          headers: BEARER_TOKEN
+            ? { Authorization: `Bearer ${BEARER_TOKEN}` }
+            : undefined,
+        })
         return new Response(res.body, {
           status: res.status,
           headers: { 'Content-Type': 'application/json' },
@@ -60,7 +67,12 @@ export const Route = createFileRoute('/api/hermes-jobs')({
         const body = await request.text()
         const res = await fetch(`${HERMES_API}/api/jobs`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            ...(BEARER_TOKEN
+              ? { Authorization: `Bearer ${BEARER_TOKEN}` }
+              : {}),
+            'Content-Type': 'application/json',
+          },
           body,
         })
         return new Response(await res.text(), {

--- a/src/routes/api/hermes-proxy/$.ts
+++ b/src/routes/api/hermes-proxy/$.ts
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { HERMES_API } from '../../../server/gateway-capabilities'
+import { BEARER_TOKEN, HERMES_API } from '../../../server/gateway-capabilities'
 import { isAuthenticated } from '../../../server/auth-middleware'
 
 async function proxyRequest(request: Request, splat: string) {
@@ -11,6 +11,10 @@ async function proxyRequest(request: Request, splat: string) {
   const headers = new Headers(request.headers)
   headers.delete('host')
   headers.delete('content-length')
+  // The Hermes gateway requires a bearer token; forward the workspace's
+  // configured token so client-side calls can hit authenticated endpoints
+  // (memory, skills, config, jobs, sessions, etc.) without a 401.
+  if (BEARER_TOKEN) headers.set('Authorization', `Bearer ${BEARER_TOKEN}`)
 
   const init: RequestInit = {
     method: request.method,

--- a/src/routes/api/models.ts
+++ b/src/routes/api/models.ts
@@ -4,6 +4,7 @@ import os from 'node:os'
 import { json } from '@tanstack/react-start'
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
+import { BEARER_TOKEN } from '../../server/gateway-capabilities'
 import {
   ensureGatewayProbed,
   getGatewayCapabilities,
@@ -110,7 +111,13 @@ function normalizeHermesModel(entry: unknown): ModelEntry | null {
 }
 
 async function fetchHermesModels(): Promise<Array<ModelEntry>> {
-  const response = await fetch(`${HERMES_API_URL}/v1/models`)
+  // The Hermes gateway requires a bearer token for /v1/models.
+  // Without it, every call returned 401 and bubbled up as a 503 to the UI,
+  // which then left the model selector empty and the dashboard offline.
+  const headers: Record<string, string> = BEARER_TOKEN
+    ? { Authorization: `Bearer ${BEARER_TOKEN}` }
+    : {}
+  const response = await fetch(`${HERMES_API_URL}/v1/models`, { headers })
   if (!response.ok)
     throw new Error(`Hermes models request failed (${response.status})`)
   const payload = asRecord(await response.json())

--- a/src/screens/conductor/components/conductor-home.tsx
+++ b/src/screens/conductor/components/conductor-home.tsx
@@ -5,7 +5,7 @@
  * the split-component architecture.
  */
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { HugeiconsIcon } from '@hugeicons/react'
 import {
   ArrowRight01Icon,
@@ -118,11 +118,14 @@ export function ConductorHome({ conductor, goalDraft, setGoalDraft, onSubmit, on
   const [historyCostExpanded, setHistoryCostExpanded] = useState(false)
   const [now, setNowState] = useState(() => Date.now())
 
-  // Refresh "now" periodically for relative timestamps
-  useState(() => {
+  // Refresh "now" periodically for relative timestamps.
+  // Use useEffect instead of useState's lazy init: the latter runs during
+  // SSR, and `window` is undefined on the server, so it crashed every
+  // /conductor render with "ReferenceError: window is not defined".
+  useEffect(() => {
     const timer = window.setInterval(() => setNowState(Date.now()), 10_000)
     return () => window.clearInterval(timer)
-  })
+  }, [])
 
   const selectedHistoryEntry = conductor.selectedHistoryEntry
   const hasMissionHistory = conductor.missionHistory.length > 0


### PR DESCRIPTION
## Summary

The Hermes gateway requires a bearer token (`HERMES_API_TOKEN`) for any authenticated endpoint, but three Studio route handlers were calling the gateway without forwarding the workspace's token. Every call bounced off a `401` from the gateway and surfaced in the UI as either a `503` (`/api/models`) or a silent 401 (`/api/hermes-proxy/*`, `/api/hermes-jobs`). This PR forwards the configured bearer token from each affected route, and fixes a related SSR crash on `/conductor`.

## What's changed

- **`src/routes/api/models.ts`** — `fetchHermesModels()` now passes `Authorization: Bearer ***` when calling `${HERMES_API_URL}/v1/models`. Before this the model selector was empty and the dashboard reported the model as offline, even though a direct `curl /v1/models` worked.

- **`src/routes/api/hermes-proxy/$.ts`** — the proxy now forwards the bearer token to the upstream so client-side calls hit memory, skills, config, jobs, sessions, etc. without bouncing off a 401.

- **`src/routes/api/hermes-jobs.ts`** — both `GET` and `POST` handlers forward the bearer token to `${HERMES_API}/api/jobs`. The 503 "capability unavailable" fallback for gateways that don't implement jobs is left intact.

- **`src/screens/conductor/components/conductor-home.tsx`** — the "refresh now" interval was registered inside a `useState` lazy init, which runs during server rendering where `window` is undefined. This crashed every `/conductor` render with `ReferenceError: window is not defined`. Switched to `useEffect` so the interval only runs on the client.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean.
- [x] With `HERMES_API_TOKEN` set, `/api/models` returns `200 {"ok":true,"data":[{"id":"hermes-agent",...}]}` (was `503`).
- [x] `/api/hermes-proxy/api/skills`, `/api/hermes-proxy/api/memory`, `/api/hermes-proxy/api/config` no longer return `404` from the proxy itself; the actual capability depends on the gateway.
- [x] `/api/hermes-jobs` with a gateway that implements jobs returns `200`; without it, the existing `{"code":"capability_unavailable",...}` `503` is still served.
- [x] `/conductor` no longer crashes with `window is not defined` in the SSR logs.

## Notes

This PR only adds token forwarding and the one-line SSR fix; it does not change capability detection, the CSP, the onboarding flow, or session-shape handling. Those are intentionally left for separate discussions.
