### PR TITLE
fix: add Bearer auth to Gateway API calls and v0.19.0 response compat

### DIFF
--- a/src/routes/api/hermes-jobs.ts
+++ b/src/routes/api/hermes-jobs.ts
@@ -34,7 +34,10 @@ export const Route = createFileRoute('/api/hermes-jobs')({
         const url = new URL(request.url)
         const params = url.searchParams.toString()
         const target = `${HERMES_API}/api/jobs${params ? `?${params}` : ''}`
-        const res = await fetch(target)
+        const token = process.env.HERMES_API_TOKEN || process.env.HERMES_API_SERVER_KEY || ''
+        const res = await fetch(target, {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        })
         return new Response(res.body, {
           status: res.status,
           headers: { 'Content-Type': 'application/json' },
@@ -58,9 +61,13 @@ export const Route = createFileRoute('/api/hermes-jobs')({
           )
         }
         const body = await request.text()
+        const token = process.env.HERMES_API_TOKEN || process.env.HERMES_API_SERVER_KEY || ''
         const res = await fetch(`${HERMES_API}/api/jobs`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
           body,
         })
         return new Response(await res.text(), {

--- a/src/server/hermes-api.ts
+++ b/src/server/hermes-api.ts
@@ -117,10 +117,10 @@ export async function listSessions(
   limit = 50,
   offset = 0,
 ): Promise<Array<HermesSession>> {
-  const resp = await hermesGet<{ items: Array<HermesSession>; total: number }>(
+  const resp = await hermesGet<{ data?: Array<HermesSession>; items?: Array<HermesSession>; total?: number }>(
     `/api/sessions?limit=${limit}&offset=${offset}`,
   )
-  return resp.items
+  return (resp.data ?? resp.items ?? []) as Array<HermesSession>
 }
 
 export async function getSession(sessionId: string): Promise<HermesSession> {
@@ -160,10 +160,10 @@ export async function deleteSession(sessionId: string): Promise<void> {
 export async function getMessages(
   sessionId: string,
 ): Promise<Array<HermesMessage>> {
-  const resp = await hermesGet<{ items: Array<HermesMessage>; total: number }>(
+  const resp = await hermesGet<{ data?: Array<HermesMessage>; items?: Array<HermesMessage>; total?: number }>(
     `/api/sessions/${sessionId}/messages`,
   )
-  return resp.items
+  return (resp.data ?? resp.items ?? []) as Array<HermesMessage>
 }
 
 export async function searchSessions(


### PR DESCRIPTION
Two fixes needed for Hermes Agent v0.19.0 compatibility:

1. **hermes-jobs.ts**: Gateway API calls (GET/POST) were missing Authorization headers, causing 401 errors from v0.19.0's stricter API. Added Bearer token from `HERMES_API_TOKEN`/`HERMES_API_SERVER_KEY` env vars.

2. **hermes-api.ts**: v0.19.0 changed session/message list response from `{items: [...]}` to `{data: [...]}`. Updated `listSessions()` and `getMessages()` to handle both formats with `data ?? items ?? []` fallback.