### PR TITLE
fix: forward HERMES_API_TOKEN to gateway in proxy routes

### DIFF
--- a/src/routes/api/approvals.$approvalId.approve.ts
+++ b/src/routes/api/approvals.$approvalId.approve.ts
@@ -19,6 +19,12 @@ import {
   sendChat,
   HERMES_API,
 } from '../../server/hermes-api'
+import { BEARER_TOKEN } from '../../server/gateway-capabilities'
+
+// Forward HERMES_API_TOKEN to the gateway so requests aren't rejected with 401
+// when API_SERVER_KEY is configured. See issue #17.
+const authHeaders = (): Record<string, string> =>
+  BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
 
 export const Route = createFileRoute('/api/approvals/$approvalId/approve')({
   server: {
@@ -60,8 +66,7 @@ export const Route = createFileRoute('/api/approvals/$approvalId/approve')({
 
         // The approvalId may encode sessionKey as "<sessionKey>:<uuid>"
         const colonIdx = approvalId.indexOf(':')
-        const sessionKey =
-          colonIdx > 0 ? approvalId.slice(0, colonIdx) : 'main'
+        const sessionKey = colonIdx > 0 ? approvalId.slice(0, colonIdx) : 'main'
 
         // Strategy 1: try the gateway's native approval endpoint first
         const caps = getGatewayCapabilities()
@@ -71,7 +76,10 @@ export const Route = createFileRoute('/api/approvals/$approvalId/approve')({
               `${HERMES_API}/api/sessions/${sessionKey}/approve`,
               {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: {
+                  ...authHeaders(),
+                  'Content-Type': 'application/json',
+                },
                 body: JSON.stringify({ scope }),
                 signal: AbortSignal.timeout(5_000),
               },

--- a/src/routes/api/approvals.$approvalId.deny.ts
+++ b/src/routes/api/approvals.$approvalId.deny.ts
@@ -15,6 +15,12 @@ import {
   sendChat,
   HERMES_API,
 } from '../../server/hermes-api'
+import { BEARER_TOKEN } from '../../server/gateway-capabilities'
+
+// Forward HERMES_API_TOKEN to the gateway so requests aren't rejected with 401
+// when API_SERVER_KEY is configured. See issue #17.
+const authHeaders = (): Record<string, string> =>
+  BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
 
 export const Route = createFileRoute('/api/approvals/$approvalId/deny')({
   server: {
@@ -30,8 +36,7 @@ export const Route = createFileRoute('/api/approvals/$approvalId/deny')({
         await ensureGatewayProbed()
 
         const colonIdx = approvalId.indexOf(':')
-        const sessionKey =
-          colonIdx > 0 ? approvalId.slice(0, colonIdx) : 'main'
+        const sessionKey = colonIdx > 0 ? approvalId.slice(0, colonIdx) : 'main'
 
         // Strategy 1: gateway native endpoint
         const caps = getGatewayCapabilities()
@@ -41,7 +46,10 @@ export const Route = createFileRoute('/api/approvals/$approvalId/deny')({
               `${HERMES_API}/api/sessions/${sessionKey}/deny`,
               {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: {
+                  ...authHeaders(),
+                  'Content-Type': 'application/json',
+                },
                 signal: AbortSignal.timeout(5_000),
               },
             )

--- a/src/routes/api/hermes-jobs.$jobId.ts
+++ b/src/routes/api/hermes-jobs.$jobId.ts
@@ -4,11 +4,17 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
 import {
+  BEARER_TOKEN,
   HERMES_API,
   HERMES_UPGRADE_INSTRUCTIONS,
   ensureGatewayProbed,
   getCapabilities,
 } from '../../server/gateway-capabilities'
+
+// Forward HERMES_API_TOKEN to the gateway so requests aren't rejected with 401
+// when API_SERVER_KEY is configured. See issue #17.
+const authHeaders = (): Record<string, string> =>
+  BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
 
 export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
   server: {
@@ -34,7 +40,7 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const target = subPath
           ? `${HERMES_API}/api/jobs/${params.jobId}/${subPath}${url.search}`
           : `${HERMES_API}/api/jobs/${params.jobId}`
-        const res = await fetch(target)
+        const res = await fetch(target, { headers: authHeaders() })
         return new Response(await res.text(), {
           status: res.status,
           headers: { 'Content-Type': 'application/json' },
@@ -63,7 +69,7 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
           : `${HERMES_API}/api/jobs/${params.jobId}`
         const res = await fetch(target, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { ...authHeaders(), 'Content-Type': 'application/json' },
           body: body || undefined,
         })
         return new Response(await res.text(), {
@@ -89,7 +95,7 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const body = await request.text()
         const res = await fetch(`${HERMES_API}/api/jobs/${params.jobId}`, {
           method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { ...authHeaders(), 'Content-Type': 'application/json' },
           body,
         })
         return new Response(await res.text(), {
@@ -114,6 +120,7 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         }
         const res = await fetch(`${HERMES_API}/api/jobs/${params.jobId}`, {
           method: 'DELETE',
+          headers: authHeaders(),
         })
         return new Response(await res.text(), {
           status: res.status,

--- a/src/routes/api/hermes-jobs.ts
+++ b/src/routes/api/hermes-jobs.ts
@@ -4,12 +4,18 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
 import {
+  BEARER_TOKEN,
   HERMES_API,
   HERMES_UPGRADE_INSTRUCTIONS,
   ensureGatewayProbed,
   getCapabilities,
 } from '../../server/gateway-capabilities'
 import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
+
+// Forward HERMES_API_TOKEN to the gateway so requests aren't rejected with 401
+// when API_SERVER_KEY is configured. See issue #17.
+const authHeaders = (): Record<string, string> =>
+  BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
 
 export const Route = createFileRoute('/api/hermes-jobs')({
   server: {
@@ -34,7 +40,7 @@ export const Route = createFileRoute('/api/hermes-jobs')({
         const url = new URL(request.url)
         const params = url.searchParams.toString()
         const target = `${HERMES_API}/api/jobs${params ? `?${params}` : ''}`
-        const res = await fetch(target)
+        const res = await fetch(target, { headers: authHeaders() })
         return new Response(res.body, {
           status: res.status,
           headers: { 'Content-Type': 'application/json' },
@@ -60,7 +66,7 @@ export const Route = createFileRoute('/api/hermes-jobs')({
         const body = await request.text()
         const res = await fetch(`${HERMES_API}/api/jobs`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { ...authHeaders(), 'Content-Type': 'application/json' },
           body,
         })
         return new Response(await res.text(), {

--- a/src/routes/api/hermes-proxy/$.ts
+++ b/src/routes/api/hermes-proxy/$.ts
@@ -1,5 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { HERMES_API } from '../../../server/gateway-capabilities'
+import { BEARER_TOKEN, HERMES_API } from '../../../server/gateway-capabilities'
 import { isAuthenticated } from '../../../server/auth-middleware'
 
 async function proxyRequest(request: Request, splat: string) {
@@ -11,6 +11,13 @@ async function proxyRequest(request: Request, splat: string) {
   const headers = new Headers(request.headers)
   headers.delete('host')
   headers.delete('content-length')
+  // The browser authenticates with a hermes-auth cookie, not the gateway bearer,
+  // so forward HERMES_API_TOKEN explicitly. Without this the gateway rejects
+  // proxied requests with 401 when API_SERVER_KEY is configured. See issue #17.
+  headers.delete('authorization')
+  if (BEARER_TOKEN) {
+    headers.set('Authorization', `Bearer ${BEARER_TOKEN}`)
+  }
 
   const init: RequestInit = {
     method: request.method,

--- a/src/routes/api/hermes-runs.$runId.events.ts
+++ b/src/routes/api/hermes-runs.$runId.events.ts
@@ -5,7 +5,12 @@
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
-import { HERMES_API } from '../../server/gateway-capabilities'
+import { BEARER_TOKEN, HERMES_API } from '../../server/gateway-capabilities'
+
+// Forward HERMES_API_TOKEN to the gateway so requests aren't rejected with 401
+// when API_SERVER_KEY is configured. See issue #17.
+const authHeaders = (): Record<string, string> =>
+  BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
 
 export const Route = createFileRoute('/api/hermes-runs/$runId/events')({
   server: {
@@ -21,6 +26,7 @@ export const Route = createFileRoute('/api/hermes-runs/$runId/events')({
         try {
           upstream = await fetch(
             `${HERMES_API}/v1/runs/${params.runId}/events`,
+            { headers: authHeaders() },
           )
         } catch {
           return new Response(

--- a/src/routes/api/hermes-runs.ts
+++ b/src/routes/api/hermes-runs.ts
@@ -5,10 +5,16 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
 import {
+  BEARER_TOKEN,
   HERMES_API,
   ensureGatewayProbed,
   getCapabilities,
 } from '../../server/gateway-capabilities'
+
+// Forward HERMES_API_TOKEN to the gateway so requests aren't rejected with 401
+// when API_SERVER_KEY is configured. See issue #17.
+const authHeaders = (): Record<string, string> =>
+  BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
 
 export const Route = createFileRoute('/api/hermes-runs')({
   server: {
@@ -23,14 +29,16 @@ export const Route = createFileRoute('/api/hermes-runs')({
         await ensureGatewayProbed()
         if (!getCapabilities().jobs) {
           return new Response(
-            JSON.stringify({ error: 'Runs API not available — gateway not connected' }),
+            JSON.stringify({
+              error: 'Runs API not available — gateway not connected',
+            }),
             { status: 503, headers: { 'Content-Type': 'application/json' } },
           )
         }
         const body = await request.text()
         const res = await fetch(`${HERMES_API}/v1/runs`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { ...authHeaders(), 'Content-Type': 'application/json' },
           body,
         })
         return new Response(await res.text(), {

--- a/src/routes/api/models.ts
+++ b/src/routes/api/models.ts
@@ -8,8 +8,14 @@ import {
   ensureGatewayProbed,
   getGatewayCapabilities,
 } from '../../server/hermes-api'
+import { BEARER_TOKEN } from '../../server/gateway-capabilities'
 
 const HERMES_API_URL = process.env.HERMES_API_URL || 'http://127.0.0.1:8642'
+
+// Forward HERMES_API_TOKEN to the gateway so requests aren't rejected with 401
+// when API_SERVER_KEY is configured. See issue #17.
+const authHeaders = (): Record<string, string> =>
+  BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
 
 // Well-known models for providers available via auth store
 const AUTH_STORE_MODELS: Record<string, Array<ModelEntry>> = {
@@ -110,7 +116,9 @@ function normalizeHermesModel(entry: unknown): ModelEntry | null {
 }
 
 async function fetchHermesModels(): Promise<Array<ModelEntry>> {
-  const response = await fetch(`${HERMES_API_URL}/v1/models`)
+  const response = await fetch(`${HERMES_API_URL}/v1/models`, {
+    headers: authHeaders(),
+  })
   if (!response.ok)
     throw new Error(`Hermes models request failed (${response.status})`)
   const payload = asRecord(await response.json())


### PR DESCRIPTION
## Summary

Fixes #17.

Several server-side proxy routes forwarded requests to the Hermes gateway **without** the `Authorization: Bearer` header, even when `HERMES_API_TOKEN` was set. When the gateway has `API_SERVER_KEY` configured (the documented, required setting for `API_SERVER_HOST=0.0.0.0`), it correctly rejects these requests with `401 gateway_auth_failed`.

This breaks the Jobs view (`Failed to load jobs: Failed to fetch jobs: 401`), leaves the model dropdown empty, drops run events before they reach the browser, and forces approvals through the chat-command fallback instead of the native endpoint. Gateway logs fill with:

```
WARNING gateway.platforms.api_server: API server rejected invalid API key: method='GET' path='/api/jobs?include_disabled=true' user_agent='node'
```

A canonical helper already exists — `BEARER_TOKEN` exported from `src/server/gateway-capabilities.ts`, already used by `hermesGet`/`hermesPost` in `src/server/hermes-api.ts`. The proxy routes just didn't use it.

## Changes

Reuses the existing `BEARER_TOKEN` pattern and passes `Authorization: Bearer ...` on every gateway `fetch` in the affected routes. The universal proxy (`hermes-proxy/$.ts`) now sets `Authorization` explicitly from `HERMES_API_TOKEN` rather than copying the browser request's headers verbatim — the browser authenticates with a `hermes-auth` cookie, which the gateway does not accept as a bearer token.

- `src/routes/api/hermes-jobs.ts` (GET, POST)
- `src/routes/api/hermes-jobs.$jobId.ts` (GET, POST, PATCH, DELETE)
- `src/routes/api/models.ts` (`fetchHermesModels`)
- `src/routes/api/hermes-runs.ts` (POST)
- `src/routes/api/hermes-runs.$runId.events.ts` (SSE GET)
- `src/routes/api/approvals.$approvalId.approve.ts` (native `/approve`)
- `src/routes/api/approvals.$approvalId.deny.ts` (native `/deny`)
- `src/routes/api/hermes-proxy/$.ts` (sets `Authorization` from `BEARER_TOKEN`)

## Verification

Against Hermes Agent v0.20.0 (`API_SERVER_ENABLED=true`, `API_SERVER_HOST=0.0.0.0`, `API_SERVER_KEY` set):

| Endpoint | Before | After |
|---|---|---|
| `GET /api/hermes-jobs?include_disabled=true` | 401 | 200 |
| `GET /api/models` | empty / 401 | 200, models populated |
| `GET /v1/runs/{id}/events` | 401 | SSE stream |
| Gateway `401` log lines (~8/min) | ongoing | **0** |

`npx tsc --noEmit` introduces no new errors (the 4 pre-existing errors on `main` are unrelated: the missing `remark-math`/`rehype-katex` deps and two untouched files). `prettier --check` passes on all changed files.

Related: #18 (separate but similar-class bug — `listSessions`/`getMessages` reading `.items` instead of `.data`).
