### PR TITLE
fix: read session/message lists from OpenAI-list `data` shape

### DIFF
--- a/src/routes/api/context-usage.ts
+++ b/src/routes/api/context-usage.ts
@@ -89,11 +89,18 @@ export const Route = createFileRoute('/api/context-usage')({
                 },
               )
               if (listRes.ok) {
-                const listData = (await listRes.json()) as {
-                  items?: Array<Record<string, unknown>>
-                }
-                if (listData.items && listData.items.length > 0) {
-                  sessionData = listData.items[0]
+                const listData = await listRes.json()
+                // The gateway returns OpenAI-list shape { object, data: [...] };
+                // accept items | data | messages | array (see issue #18).
+                const fallbackList: Array<Record<string, unknown>> =
+                  Array.isArray(listData)
+                    ? listData
+                    : (listData?.items ??
+                      listData?.data ??
+                      listData?.messages ??
+                      [])
+                if (Array.isArray(fallbackList) && fallbackList.length > 0) {
+                  sessionData = fallbackList[0]
                 }
               }
             } catch {
@@ -157,14 +164,19 @@ export const Route = createFileRoute('/api/context-usage')({
                   },
                 )
                 if (msgRes.ok) {
-                  const msgData = (await msgRes.json()) as {
-                    items?: Array<{
-                      content?: string
-                      tool_calls?: unknown
-                      reasoning?: string
-                    }>
-                  }
-                  const messages = msgData.items || []
+                  const msgData = await msgRes.json()
+                  // The gateway returns { object, session_id, data: [...] };
+                  // accept items | data | messages | array (see issue #18).
+                  const messages: Array<{
+                    content?: string
+                    tool_calls?: unknown
+                    reasoning?: string
+                  }> = Array.isArray(msgData)
+                    ? msgData
+                    : (msgData?.items ??
+                      msgData?.data ??
+                      msgData?.messages ??
+                      [])
                   let totalChars = 0
                   for (const msg of messages) {
                     totalChars += (msg.content || '').length

--- a/src/server/hermes-api.ts
+++ b/src/server/hermes-api.ts
@@ -68,6 +68,26 @@ async function hermesGet<T>(path: string): Promise<T> {
   return res.json() as Promise<T>
 }
 
+/**
+ * Pull a list of items out of a gateway response regardless of which key the
+ * payload uses. The Hermes gateway (v0.18/0.20) returns the OpenAI-list shape
+ * `{ object: "list", data: [...] }` for sessions and
+ * `{ object: "list", session_id, data: [...] }` for messages, but older or
+ * alternate endpoints have used `items`/`messages`. Return the first array we
+ * find, falling back to the payload itself when it is already an array. See
+ * issue #18 — reading `resp.items` only left session/message history empty.
+ */
+function extractList<T>(resp: unknown): Array<T> {
+  if (Array.isArray(resp)) return resp
+  if (resp && typeof resp === 'object') {
+    const record = resp as Record<string, unknown>
+    for (const key of ['items', 'data', 'messages', 'results']) {
+      if (Array.isArray(record[key])) return record[key] as Array<T>
+    }
+  }
+  return []
+}
+
 async function hermesPost<T>(path: string, body?: unknown): Promise<T> {
   const res = await fetch(`${HERMES_API}${path}`, {
     method: 'POST',
@@ -117,10 +137,10 @@ export async function listSessions(
   limit = 50,
   offset = 0,
 ): Promise<Array<HermesSession>> {
-  const resp = await hermesGet<{ items: Array<HermesSession>; total: number }>(
+  const resp = await hermesGet<unknown>(
     `/api/sessions?limit=${limit}&offset=${offset}`,
   )
-  return resp.items
+  return extractList<HermesSession>(resp)
 }
 
 export async function getSession(sessionId: string): Promise<HermesSession> {
@@ -160,10 +180,8 @@ export async function deleteSession(sessionId: string): Promise<void> {
 export async function getMessages(
   sessionId: string,
 ): Promise<Array<HermesMessage>> {
-  const resp = await hermesGet<{ items: Array<HermesMessage>; total: number }>(
-    `/api/sessions/${sessionId}/messages`,
-  )
-  return resp.items
+  const resp = await hermesGet<unknown>(`/api/sessions/${sessionId}/messages`)
+  return extractList<HermesMessage>(resp)
 }
 
 export async function searchSessions(


### PR DESCRIPTION
## Summary

Fixes #18.

`listSessions()` and `getMessages()` in `src/server/hermes-api.ts` read `resp.items`, but the Hermes gateway (v0.18/0.20) returns the OpenAI-list shape:

```
GET /api/sessions?limit=50&offset=0
→ 200 {"object":"list","data":[{"id":"...","source":"api_server","message_count":2,...}]}

GET /api/sessions/{id}/messages
→ 200 {"object":"list","session_id":"...","data":[{"id":70,"role":"user",...}]}
```

So `resp.items` was `undefined`, the session history rendered empty on page reload, and message history never loaded — even though the data stayed intact in the gateway database. The same `.items` assumption in `src/routes/api/context-usage.ts` (~lines 95 and 161) zeroed out the context-usage estimate for sessions without `cache_read_tokens`.

This is the same class of bug as the closed issue #5 (closed without a fix landing in `main`).

## Changes

Adds a small `extractList()` helper that returns the first array it finds across `items | data | messages | results` (and the payload itself when it is already an array), then uses it in `listSessions()` and `getMessages()`. `context-usage.ts` does the same resilient lookup inline in its two spots. This mirrors what `fetchHermesModels` in `src/routes/api/models.ts` already does (`payload.data ?? payload.models`) and stays compatible if the gateway ever changes the list key again.

- `src/server/hermes-api.ts` — `extractList()` helper + `listSessions`/`getMessages` use it
- `src/routes/api/context-usage.ts` — resilient list lookup (2 spots)

## Note

`getSession`/`createSession`/`updateSession` read `resp.session`, and the gateway **does** return `{ session: {...} }` for those single-resource endpoints — so only the list endpoints are affected. The single-object shape is correct and left untouched.

## Verification

Against Hermes Agent v0.20.0 with a populated session DB:

| Endpoint (via Studio proxy) | Before | After |
|---|---|---|
| `GET /api/sessions` | `{ source: "gateway", sessions: [] }` (0) | `{ source: "gateway", sessions: [...] }` (8) |
| Session message history | empty | loads |
| Context-usage indicator | stuck at 0% | reflects conversation size |

- `npx tsc --noEmit`: no new errors (the 4 pre-existing errors on `main` are unrelated — the missing `remark-math`/`rehype-katex` deps and two untouched files)
- `npx vitest run`: **190/190 tests pass** (including `operations-aggregator.test`, which mocks `listSessions` — the call signature is unchanged)
- `prettier --check`: passes on both changed files

Related: #19 (separate bug — proxy routes missing `Authorization`).
