### PR TITLE
fix(tasks): enforce per-task access control on by-id routes (Issue #8 gap)

### DIFF
--- a/src/routes/api/tasks/$taskId.move.ts
+++ b/src/routes/api/tasks/$taskId.move.ts
@@ -3,9 +3,10 @@
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
+import { isAuthenticated, getUserIdFromRequest } from '../../../server/auth-middleware'
 import { requireJsonContentType } from '../../../server/rate-limit'
-import { moveTask } from '../../../server/task-store'
+import { getTask, moveTask } from '../../../server/task-store'
+import { canAccessTask } from '../../../server/user-profiles'
 import type { TaskColumn } from '../../../types/task'
 
 const VALID_COLUMNS: TaskColumn[] = ['backlog', 'todo', 'in_progress', 'review', 'done']
@@ -28,6 +29,12 @@ export const Route = createFileRoute('/api/tasks/$taskId/move')({
             { ok: false, error: `column must be one of: ${VALID_COLUMNS.join(', ')}` },
             { status: 400 },
           )
+        }
+
+        const existing = getTask(params.taskId)
+        // 404 (not 403) on foreign tasks so task ids don't leak (Issue #8)
+        if (!existing || !canAccessTask(getUserIdFromRequest(request), existing)) {
+          return json({ ok: false, error: 'Task not found' }, { status: 404 })
         }
 
         const task = moveTask(params.taskId, column as TaskColumn)

--- a/src/routes/api/tasks/$taskId.ts
+++ b/src/routes/api/tasks/$taskId.ts
@@ -5,9 +5,10 @@
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
+import { isAuthenticated, getUserIdFromRequest } from '../../../server/auth-middleware'
 import { requireJsonContentType } from '../../../server/rate-limit'
 import { getTask, updateTask, deleteTask } from '../../../server/task-store'
+import { canAccessTask } from '../../../server/user-profiles'
 import type { TaskColumn, TaskPriority } from '../../../types/task'
 
 const VALID_COLUMNS: TaskColumn[] = ['backlog', 'todo', 'in_progress', 'review', 'done']
@@ -21,7 +22,8 @@ export const Route = createFileRoute('/api/tasks/$taskId')({
           return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
         }
         const task = getTask(params.taskId)
-        if (!task) {
+        // 404 (not 403) on foreign tasks so task ids don't leak (Issue #8)
+        if (!task || !canAccessTask(getUserIdFromRequest(request), task)) {
           return json({ ok: false, error: 'Task not found' }, { status: 404 })
         }
         return json({ ok: true, task })
@@ -33,6 +35,11 @@ export const Route = createFileRoute('/api/tasks/$taskId')({
         }
         const csrfCheck = requireJsonContentType(request)
         if (csrfCheck) return csrfCheck
+
+        const existing = getTask(params.taskId)
+        if (!existing || !canAccessTask(getUserIdFromRequest(request), existing)) {
+          return json({ ok: false, error: 'Task not found' }, { status: 404 })
+        }
 
         const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
 
@@ -66,6 +73,10 @@ export const Route = createFileRoute('/api/tasks/$taskId')({
       DELETE: async ({ request, params }) => {
         if (!isAuthenticated(request)) {
           return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const existing = getTask(params.taskId)
+        if (!existing || !canAccessTask(getUserIdFromRequest(request), existing)) {
+          return json({ ok: false, error: 'Task not found' }, { status: 404 })
         }
         const deleted = deleteTask(params.taskId)
         if (!deleted) {

--- a/src/server/user-profiles.ts
+++ b/src/server/user-profiles.ts
@@ -118,3 +118,19 @@ export function getAccessibleProfiles(userId: string): string[] {
   if (profile.role === 'super_admin') return [] // null = all profiles
   return profile.profileIds
 }
+
+/**
+ * Check if a user may act on a task. Super admins may act on any task;
+ * regular admins only on tasks they created. A missing userId means
+ * single-user mode, where no per-user filtering applies — mirrors the
+ * list filtering in /api/tasks (Issue #8).
+ */
+export function canAccessTask(
+  userId: string | null | undefined,
+  task: { createdBy?: string | null },
+): boolean {
+  if (!userId) return true
+  const profile = getUserProfile(userId)
+  if (profile.role === 'super_admin') return true
+  return task.createdBy === userId
+}

--- a/src/test/user-profiles.test.ts
+++ b/src/test/user-profiles.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canAccessTask,
+  updateUserProfile,
+} from '../server/user-profiles'
+
+describe('canAccessTask() (Issue #8)', () => {
+  it('allows access in single-user mode (no userId)', () => {
+    expect(canAccessTask(null, { createdBy: 'someone' })).toBe(true)
+    expect(canAccessTask(undefined, { createdBy: 'someone' })).toBe(true)
+  })
+
+  it('allows a regular admin to access their own task', () => {
+    expect(canAccessTask('user-a', { createdBy: 'user-a' })).toBe(true)
+  })
+
+  it('denies a regular admin access to a foreign task', () => {
+    expect(canAccessTask('user-a', { createdBy: 'user-b' })).toBe(false)
+  })
+
+  it('denies a regular admin access to a task with no creator', () => {
+    expect(canAccessTask('user-a', {})).toBe(false)
+    expect(canAccessTask('user-a', { createdBy: null })).toBe(false)
+  })
+
+  it('allows a super admin to access any task', () => {
+    updateUserProfile('boss-user', { role: 'super_admin' })
+    expect(canAccessTask('boss-user', { createdBy: 'user-b' })).toBe(true)
+    expect(canAccessTask('boss-user', {})).toBe(true)
+  })
+})


### PR DESCRIPTION
> **Superseded by #26 (also mine) — please read first.**
>
> #26 contains all four of this PR's files and a strictly stronger version of the
> change: `canAccessTask()` there also handles `profileId` bindings and fails
> **closed** in multi-user mode, where this PR's version returns `true` when there
> is no identity.
>
> Kept open only as the small, self-contained option if you'd prefer the by-id
> authorization fix without the identity model that #26 introduces. If #26 looks
> reasonable to you, close this one in its favour.

---

## What

Extends the Issue #8 Phase-1 role filtering to the by-id task routes.

Phase 1 (0f7d283) filters `GET /api/tasks`, but `GET/PATCH/DELETE /api/tasks/:taskId` and `POST /api/tasks/:taskId/move` had no access check — a `regular_admin` could still read, edit, move, or delete **any** task if they knew (or guessed) its id, including super-admin tasks.

- Adds `canAccessTask()` to `src/server/user-profiles.ts`: super_admin → any task; regular_admin → only tasks they created; no userId (single-user mode) → unrestricted, mirroring the existing list-filter semantics.
- Enforces it in `tasks/$taskId.ts` (GET/PATCH/DELETE) and `tasks/$taskId.move.ts`.
- Returns **404** (not 403) on foreign tasks so task ids don't leak existence.
- Unit tests in `src/test/user-profiles.test.ts` (5 cases, green).

Addresses the remaining Phase-1 gap in #8. Phase 2 (profile-binding-based visibility, per the issue's Option A) is untouched and still open.

## Verification

- `npx tsc --noEmit` clean; `vitest run src/test/user-profiles.test.ts src/test/task-store.test.ts` → 16 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

