### PR TITLE
fix: Hermes Studio compat with gateway v0.20 api_server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "ioredis": "^5.10.1",
+        "katex": "^0.18.4",
         "marked": "^17.0.1",
         "motion": "^12.29.2",
         "playwright": "^1.58.2",
@@ -37,8 +38,10 @@
         "react-joyride": "^2.9.3",
         "react-markdown": "^10.1.0",
         "recharts": "^3.7.0",
+        "rehype-katex": "^7.0.1",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0",
         "shiki": "^3.21.0",
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.18",
@@ -3358,6 +3361,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -4661,6 +4670,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/comment-parser": {
@@ -6002,6 +6020,125 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -6052,6 +6189,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -6059,6 +6212,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6576,6 +6746,22 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.18.4.tgz",
+      "integrity": "sha512-IMPntbRLOU+eu88XDiFKqQ8Akhr9Tv7jDMXqPhjG9SI1JMA4DIgXk4x9k4skJz2NZJXBRbC+2pYBLj9olqcZow==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/keyv": {
@@ -7135,6 +7321,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-mdx-expression": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
@@ -7487,6 +7692,41 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math/node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -8922,6 +9162,41 @@
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
     },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-katex/node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
     "node_modules/remark-breaks": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
@@ -8948,6 +9223,22 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -9907,6 +10198,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -9927,6 +10232,20 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10108,6 +10427,20 @@
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -10901,6 +11234,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/web-vitals": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "NODE_OPTIONS=\"--max-old-space-size=2048\" vite dev --port 3000",
+    "dev": "vite dev --port 3000",
     "build": "vite build",
     "start": "NODE_OPTIONS=\"--max-old-space-size=2048\" node server-entry.js",
     "deploy": "npm run build && pkill -f 'node server-entry.js' 2>/dev/null; sleep 1; NODE_OPTIONS=\"--max-old-space-size=2048\" node server-entry.js",
@@ -38,6 +38,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "ioredis": "^5.10.1",
+    "katex": "^0.18.4",
     "marked": "^17.0.1",
     "motion": "^12.29.2",
     "playwright": "^1.58.2",
@@ -48,8 +49,10 @@
     "react-joyride": "^2.9.3",
     "react-markdown": "^10.1.0",
     "recharts": "^3.7.0",
+    "rehype-katex": "^7.0.1",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
     "shiki": "^3.21.0",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18",
@@ -109,6 +112,10 @@
     "url": "https://github.com/JPeetz/Hermes-Studio.git"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["better-sqlite3", "esbuild", "unrs-resolver"]
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "esbuild",
+      "unrs-resolver"
+    ]
   }
 }

--- a/server-entry.js
+++ b/server-entry.js
@@ -92,6 +92,10 @@ async function tryServeStatic(req, res) {
 }
 
 const httpServer = createServer(async (req, res) => {
+  // frame-ancestors can't be expressed in a <meta> CSP, so send the
+  // equivalent clickjacking guard as a real HTTP header.
+  res.setHeader('X-Frame-Options', 'DENY')
+
   // Try static files first (client assets)
   if (req.method === 'GET' || req.method === 'HEAD') {
     const served = await tryServeStatic(req, res)

--- a/src/components/settings-dialog/settings-dialog.tsx
+++ b/src/components/settings-dialog/settings-dialog.tsx
@@ -227,12 +227,11 @@ function HermesContent() {
   const [userProfileEnabled, setUserProfileEnabled] = useState(true)
 
   const fetchModelsForProvider = useCallback((providerId: string) => {
-    fetch(
-      `/api/hermes-proxy/api/available-models?provider=${encodeURIComponent(providerId)}`,
-    )
+    fetch(`/api/hermes-proxy/api/model/options`)
       .then((r) => r.json())
-      .then((d: { models?: Array<{ id: string }> }) => {
-        setAvailableModels((d.models || []).map((m) => m.id))
+      .then((d: { providers?: Array<{ slug: string; models?: Array<string> }> }) => {
+        const provider = (d.providers || []).find((p) => p.slug === providerId)
+        setAvailableModels(provider?.models || [])
       })
       .catch(() => {
         // Fall back to hardcoded

--- a/src/components/terminal/terminal-workspace.tsx
+++ b/src/components/terminal/terminal-workspace.tsx
@@ -516,7 +516,14 @@ export function TerminalWorkspace({
       terminal.loadAddon(fitAddon)
       terminal.loadAddon(webLinks)
       terminal.open(container)
-      fitAddon.fit()
+      // Container may be display:none (inactive tab) at mount → fit() throws
+      // in xterm's renderer ("reading 'dimensions'"). The refit-on-visible
+      // effect handles sizing once the tab becomes active.
+      try {
+        fitAddon.fit()
+      } catch {
+        /* ignore zero-size fit */
+      }
 
       terminal.onData(function onData(data) {
         void sendInput(tab.id, data)

--- a/src/hooks/use-feature-available.ts
+++ b/src/hooks/use-feature-available.ts
@@ -7,6 +7,10 @@ interface GatewayStatus {
 }
 
 export function useFeatureAvailable(feature: EnhancedFeature): boolean {
+  // Config is served locally (/api/hermes-config reads/writes config.yaml),
+  // so it never depends on the gateway's optional config API.
+  if (feature === 'config') return true
+
   const { data } = useQuery({
     queryKey: ['gateway-status'],
     queryFn: async () => {

--- a/src/lib/feature-gates.ts
+++ b/src/lib/feature-gates.ts
@@ -33,6 +33,9 @@ function normalizeFeature(
 }
 
 export function isFeatureAvailable(feature: EnhancedFeature): boolean {
+  // 'config' is served locally (/api/hermes-config reads/writes config.yaml),
+  // so it never depends on the gateway's optional config API.
+  if (feature === 'config') return true
   const caps = getCapabilities()
   return caps[feature] === true
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -18,13 +18,16 @@ const APP_CSP = [
   "base-uri 'self'",
   "object-src 'none'",
   "form-action 'self'",
-  "frame-ancestors 'none'",
-  "script-src 'self' 'unsafe-inline'",
-  "style-src 'self' 'unsafe-inline'",
+  // frame-ancestors can't be set via <meta> (ignored by browsers); it's sent
+  // as an X-Frame-Options header instead (see vite.config + server-entry.js).
+  // cdn.jsdelivr.net: @monaco-editor/react loads the editor from the CDN.
+  // fonts.googleapis.com / fonts.gstatic.com: Google Fonts used by several screens.
+  "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net",
+  "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com",
   "img-src 'self' data: blob: https:",
-  "font-src 'self' data:",
+  "font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com",
   "connect-src 'self' ws: wss: http: https:",
-  "worker-src 'self' blob:",
+  "worker-src 'self' blob: https://cdn.jsdelivr.net",
   "media-src 'self' blob: data:",
   "frame-src 'self' http: https:",
 ].join('; ')

--- a/src/routes/api/approvals.$approvalId.approve.ts
+++ b/src/routes/api/approvals.$approvalId.approve.ts
@@ -13,6 +13,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { requireJsonContentType } from '../../server/rate-limit'
+import { authHeaders } from '../../server/gateway-capabilities'
 import {
   ensureGatewayProbed,
   getGatewayCapabilities,
@@ -71,7 +72,7 @@ export const Route = createFileRoute('/api/approvals/$approvalId/approve')({
               `${HERMES_API}/api/sessions/${sessionKey}/approve`,
               {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: { ...authHeaders(), 'Content-Type': 'application/json' },
                 body: JSON.stringify({ scope }),
                 signal: AbortSignal.timeout(5_000),
               },

--- a/src/routes/api/approvals.$approvalId.deny.ts
+++ b/src/routes/api/approvals.$approvalId.deny.ts
@@ -9,6 +9,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { requireJsonContentType } from '../../server/rate-limit'
+import { authHeaders } from '../../server/gateway-capabilities'
 import {
   ensureGatewayProbed,
   getGatewayCapabilities,
@@ -41,7 +42,7 @@ export const Route = createFileRoute('/api/approvals/$approvalId/deny')({
               `${HERMES_API}/api/sessions/${sessionKey}/deny`,
               {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: { ...authHeaders(), 'Content-Type': 'application/json' },
                 signal: AbortSignal.timeout(5_000),
               },
             )

--- a/src/routes/api/connection-status.ts
+++ b/src/routes/api/connection-status.ts
@@ -4,7 +4,6 @@
  */
 import fs from 'node:fs'
 import path from 'node:path'
-import os from 'node:os'
 import { createFileRoute } from '@tanstack/react-router'
 import YAML from 'yaml'
 import {
@@ -12,9 +11,10 @@ import {
   ensureGatewayProbed,
   getChatMode,
 } from '../../server/gateway-capabilities'
+import { hermesHome } from '../../server/hermes-home'
 import { isAuthenticated } from '../../server/auth-middleware'
 
-const CONFIG_PATH = path.join(os.homedir(), '.hermes', 'config.yaml')
+const CONFIG_PATH = path.join(hermesHome(), 'config.yaml')
 
 function readActiveModel(): string {
   try {

--- a/src/routes/api/files.ts
+++ b/src/routes/api/files.ts
@@ -1,4 +1,3 @@
-import os from 'node:os'
 import path from 'node:path'
 import fs from 'node:fs/promises'
 import { execFile } from 'node:child_process'
@@ -9,6 +8,7 @@ import {
   isAuthenticated,
   requireLocalOrAuth,
 } from '../../server/auth-middleware'
+import { hermesHome } from '../../server/hermes-home'
 import {
   getClientIp,
   rateLimit,
@@ -22,8 +22,7 @@ const execFileAsync = promisify(execFile)
 
 const WORKSPACE_ROOT = (
   process.env.HERMES_WORKSPACE_DIR ||
-  process.env.HERMES_WORKSPACE_DIR ||
-  path.join(os.homedir(), '.hermes')
+  path.join(hermesHome())
 ).trim()
 
 type FileEntry = {

--- a/src/routes/api/hermes-config.ts
+++ b/src/routes/api/hermes-config.ts
@@ -3,16 +3,17 @@
  * Gives the web UI the same config power as `hermes setup`
  */
 import fs from 'node:fs'
-import path from 'node:path'
 import os from 'node:os'
+import path from 'node:path'
 import { createFileRoute } from '@tanstack/react-router'
 import YAML from 'yaml'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { ensureGatewayProbed } from '../../server/gateway-capabilities'
+import { hermesHome } from '../../server/hermes-home'
 
 type AuthResult = Response | true
 
-const HERMES_HOME = path.join(os.homedir(), '.hermes')
+const HERMES_HOME = hermesHome()
 const CONFIG_PATH = path.join(HERMES_HOME, 'config.yaml')
 const ENV_PATH = path.join(HERMES_HOME, '.env')
 
@@ -124,7 +125,7 @@ function checkAuthStore(providerId: string): {
 } {
   // Check Hermes auth store
   for (const storePath of [
-    path.join(os.homedir(), '.hermes', 'auth-profiles.json'),
+    path.join(HERMES_HOME, 'auth-profiles.json'),
     path.join(
       os.homedir(),
       '.openclaw',
@@ -132,8 +133,7 @@ function checkAuthStore(providerId: string): {
       'main',
       'agent',
       'auth-profiles.json',
-    ),
-  ]) {
+    ),  ]) {
     try {
       if (!fs.existsSync(storePath)) continue
       const store = JSON.parse(fs.readFileSync(storePath, 'utf-8'))

--- a/src/routes/api/hermes-jobs.$jobId.ts
+++ b/src/routes/api/hermes-jobs.$jobId.ts
@@ -6,6 +6,7 @@ import { isAuthenticated } from '../../server/auth-middleware'
 import {
   HERMES_API,
   HERMES_UPGRADE_INSTRUCTIONS,
+  authHeaders,
   ensureGatewayProbed,
   getCapabilities,
 } from '../../server/gateway-capabilities'
@@ -34,7 +35,7 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const target = subPath
           ? `${HERMES_API}/api/jobs/${params.jobId}/${subPath}${url.search}`
           : `${HERMES_API}/api/jobs/${params.jobId}`
-        const res = await fetch(target)
+        const res = await fetch(target, { headers: authHeaders() })
         return new Response(await res.text(), {
           status: res.status,
           headers: { 'Content-Type': 'application/json' },
@@ -63,7 +64,7 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
           : `${HERMES_API}/api/jobs/${params.jobId}`
         const res = await fetch(target, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { ...authHeaders(), 'Content-Type': 'application/json' },
           body: body || undefined,
         })
         return new Response(await res.text(), {
@@ -89,7 +90,7 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         const body = await request.text()
         const res = await fetch(`${HERMES_API}/api/jobs/${params.jobId}`, {
           method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { ...authHeaders(), 'Content-Type': 'application/json' },
           body,
         })
         return new Response(await res.text(), {
@@ -114,6 +115,7 @@ export const Route = createFileRoute('/api/hermes-jobs/$jobId')({
         }
         const res = await fetch(`${HERMES_API}/api/jobs/${params.jobId}`, {
           method: 'DELETE',
+          headers: authHeaders(),
         })
         return new Response(await res.text(), {
           status: res.status,

--- a/src/routes/api/hermes-jobs.ts
+++ b/src/routes/api/hermes-jobs.ts
@@ -6,6 +6,7 @@ import { isAuthenticated } from '../../server/auth-middleware'
 import {
   HERMES_API,
   HERMES_UPGRADE_INSTRUCTIONS,
+  authHeaders,
   ensureGatewayProbed,
   getCapabilities,
 } from '../../server/gateway-capabilities'
@@ -34,7 +35,7 @@ export const Route = createFileRoute('/api/hermes-jobs')({
         const url = new URL(request.url)
         const params = url.searchParams.toString()
         const target = `${HERMES_API}/api/jobs${params ? `?${params}` : ''}`
-        const res = await fetch(target)
+        const res = await fetch(target, { headers: authHeaders() })
         return new Response(res.body, {
           status: res.status,
           headers: { 'Content-Type': 'application/json' },
@@ -60,7 +61,7 @@ export const Route = createFileRoute('/api/hermes-jobs')({
         const body = await request.text()
         const res = await fetch(`${HERMES_API}/api/jobs`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { ...authHeaders(), 'Content-Type': 'application/json' },
           body,
         })
         return new Response(await res.text(), {

--- a/src/routes/api/hermes-proxy/$.ts
+++ b/src/routes/api/hermes-proxy/$.ts
@@ -2,6 +2,8 @@ import { createFileRoute } from '@tanstack/react-router'
 import { HERMES_API } from '../../../server/gateway-capabilities'
 import { isAuthenticated } from '../../../server/auth-middleware'
 
+const HERMES_API_TOKEN = process.env.HERMES_API_TOKEN || ''
+
 async function proxyRequest(request: Request, splat: string) {
   const incomingUrl = new URL(request.url)
   const targetPath = splat.startsWith('/') ? splat : `/${splat}`
@@ -11,6 +13,11 @@ async function proxyRequest(request: Request, splat: string) {
   const headers = new Headers(request.headers)
   headers.delete('host')
   headers.delete('content-length')
+
+  // The browser never holds the gateway token — authenticate server-side.
+  if (HERMES_API_TOKEN && !headers.has('authorization')) {
+    headers.set('Authorization', `Bearer ${HERMES_API_TOKEN}`)
+  }
 
   const init: RequestInit = {
     method: request.method,

--- a/src/routes/api/mcp/servers.ts
+++ b/src/routes/api/mcp/servers.ts
@@ -1,23 +1,16 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import os from 'node:os'
 import { createFileRoute } from '@tanstack/react-router'
 import YAML from 'yaml'
 import { isAuthenticated } from '../../../server/auth-middleware'
 import { requireJsonContentType } from '../../../server/rate-limit'
-import {
-  BEARER_TOKEN,
-  HERMES_API,
-  ensureGatewayProbed,
-  getCapabilities,
-} from '../../../server/gateway-capabilities'
-import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
+import { hermesHome } from '../../../server/hermes-home'
 
 type AuthResult = Response | true
 
 // ─── Local config file I/O (mirrors hermes-config.ts) ────────────────────────
 
-const HERMES_HOME = path.join(os.homedir(), '.hermes')
+const HERMES_HOME = hermesHome()
 const CONFIG_PATH = path.join(HERMES_HOME, 'config.yaml')
 
 function readConfig(): Record<string, unknown> {
@@ -69,10 +62,6 @@ type McpServerRecord = {
   timeout?: number
   connectTimeout?: number
   auth?: unknown
-}
-
-function authHeaders(): Record<string, string> {
-  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
 }
 
 function toStringRecord(value: unknown): Record<string, string> | undefined {
@@ -146,37 +135,13 @@ export const Route = createFileRoute('/api/mcp/servers')({
         const authResult = isAuthenticated(request) as AuthResult
         if (authResult !== true) return authResult
 
-        await ensureGatewayProbed()
-        if (!getCapabilities().config) {
-          return Response.json({
-            ...createCapabilityUnavailablePayload('config', {
-              message:
-                'Gateway config API unavailable. You can still draft MCP config snippets locally.',
-            }),
-            servers: [],
-          })
-        }
-
         try {
-          const response = await fetch(`${HERMES_API}/api/config`, {
-            headers: authHeaders(),
-          })
-
-          if (!response.ok) {
-            return Response.json({
-              servers: [],
-              ok: false,
-              message: `Failed to load MCP servers from gateway config (${response.status}).`,
-            })
-          }
-
-          const payload = (await response.json().catch(() => ({}))) as unknown
-          return Response.json({ ok: true, servers: readServers(payload) })
-        } catch {
+          return Response.json({ ok: true, servers: readServers(readConfig()) })
+        } catch (err) {
           return Response.json({
             servers: [],
             ok: false,
-            message: 'Could not reach Hermes gateway config endpoint.',
+            message: err instanceof Error ? err.message : String(err),
           })
         }
       },

--- a/src/routes/api/models.ts
+++ b/src/routes/api/models.ts
@@ -4,12 +4,20 @@ import os from 'node:os'
 import { json } from '@tanstack/react-start'
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../server/auth-middleware'
+import { hermesHome } from '../../server/hermes-home'
 import {
   ensureGatewayProbed,
   getGatewayCapabilities,
 } from '../../server/hermes-api'
 
 const HERMES_API_URL = process.env.HERMES_API_URL || 'http://127.0.0.1:8642'
+const HERMES_API_TOKEN = process.env.HERMES_API_TOKEN || ''
+
+function gatewayHeaders(): Record<string, string> {
+  return HERMES_API_TOKEN
+    ? { Authorization: `Bearer ${HERMES_API_TOKEN}` }
+    : {}
+}
 
 // Well-known models for providers available via auth store
 const AUTH_STORE_MODELS: Record<string, Array<ModelEntry>> = {
@@ -32,7 +40,7 @@ const AUTH_STORE_MODELS: Record<string, Array<ModelEntry>> = {
 function getAuthStoreModels(): Array<ModelEntry> {
   const extra: Array<ModelEntry> = []
   for (const storePath of [
-    path.join(os.homedir(), '.hermes', 'auth-profiles.json'),
+    path.join(hermesHome(), 'auth-profiles.json'),
     path.join(
       os.homedir(),
       '.openclaw',
@@ -110,7 +118,9 @@ function normalizeHermesModel(entry: unknown): ModelEntry | null {
 }
 
 async function fetchHermesModels(): Promise<Array<ModelEntry>> {
-  const response = await fetch(`${HERMES_API_URL}/v1/models`)
+  const response = await fetch(`${HERMES_API_URL}/v1/models`, {
+    headers: gatewayHeaders(),
+  })
   if (!response.ok)
     throw new Error(`Hermes models request failed (${response.status})`)
   const payload = asRecord(await response.json())

--- a/src/routes/api/oauth.poll-token.ts
+++ b/src/routes/api/oauth.poll-token.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { z } from 'zod'
+import { hermesHome } from '../../server/hermes-home'
 
 const BodySchema = z.object({
   provider: z.string(),
@@ -11,7 +11,7 @@ const BodySchema = z.object({
 })
 
 function saveNousTokens(accessToken: string, refreshToken?: string) {
-  const hermesDir = path.join(os.homedir(), '.hermes')
+  const hermesDir = hermesHome()
   const authPath = path.join(hermesDir, 'auth.json')
 
   let existing: Record<string, unknown> = {}

--- a/src/routes/api/session-status.ts
+++ b/src/routes/api/session-status.ts
@@ -1,14 +1,43 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
+import fs from 'node:fs'
+import path from 'node:path'
+import YAML from 'yaml'
 import {
   ensureGatewayProbed,
-  getConfig,
   getGatewayCapabilities,
   getSession,
   listSessions,
 } from '../../server/hermes-api'
+import { hermesHome } from '../../server/hermes-home'
 import { isSyntheticSessionKey } from '../../server/session-utils'
 import { isAuthenticated } from '@/server/auth-middleware'
+
+/** Read the configured default model/provider from ~/.hermes/config.yaml. */
+function readLocalConfig(): { model: string; provider: string } {
+  try {
+    const raw = fs.readFileSync(
+      path.join(hermesHome(), 'config.yaml'),
+      'utf-8',
+    )
+    const config = (YAML.parse(raw) as Record<string, unknown>) || {}
+    const modelField = config.model
+    if (typeof modelField === 'string') {
+      return { model: modelField, provider: (config.provider as string) || '' }
+    }
+    if (modelField && typeof modelField === 'object') {
+      const nested = modelField as Record<string, unknown>
+      return {
+        model: (nested.default as string) || '',
+        provider:
+          (nested.provider as string) || (config.provider as string) || '',
+      }
+    }
+    return { model: '', provider: (config.provider as string) || '' }
+  } catch {
+    return { model: '', provider: '' }
+  }
+}
 
 export const Route = createFileRoute('/api/session-status')({
   server: {
@@ -62,9 +91,15 @@ export const Route = createFileRoute('/api/session-status')({
           }
 
           const session = await getSession(sessionKey)
-          const config = capabilities.config
-            ? await getConfig()
-            : ({ model: '', provider: '' } as const)
+          const localConfig = readLocalConfig()
+          // The gateway persists its virtual model name ("hermes-agent") on the
+          // session row; surface the real configured model instead.
+          const sessionModel = session.model ?? ''
+          const model =
+            sessionModel && sessionModel !== 'hermes-agent'
+              ? sessionModel
+              : localConfig.model
+          const modelProvider = localConfig.provider
 
           const inputTokens = session.input_tokens ?? 0
           const outputTokens = session.output_tokens ?? 0
@@ -75,8 +110,8 @@ export const Route = createFileRoute('/api/session-status')({
               status: session.ended_at ? 'ended' : 'idle',
               sessionKey: session.id,
               sessionLabel: session.title ?? '',
-              model: session.model ?? config.model ?? '',
-              modelProvider: config.provider ?? '',
+              model,
+              modelProvider,
               inputTokens,
               outputTokens,
               totalTokens: inputTokens + outputTokens,
@@ -85,8 +120,8 @@ export const Route = createFileRoute('/api/session-status')({
                   key: session.id,
                   agentId: session.id,
                   label: session.title ?? session.id,
-                  model: session.model ?? config.model ?? '',
-                  modelProvider: config.provider ?? '',
+                  model,
+                  modelProvider,
                   updatedAt: session.last_active ?? session.started_at ?? 0,
                   usage: {
                     input: inputTokens,

--- a/src/routes/api/skills.ts
+++ b/src/routes/api/skills.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
+import { hermesHome } from '../../server/hermes-home'
 import {
   ensureGatewayProbed,
   getCapabilities,
@@ -106,7 +106,7 @@ function slugify(input: string): string {
 
 type StudioPrefs = { disabled: Array<string> }
 
-const PREFS_PATH = path.join(os.homedir(), '.hermes', 'skills', '.studio-prefs.json')
+const PREFS_PATH = path.join(hermesHome(), 'skills', '.studio-prefs.json')
 
 function readLocalPrefs(): StudioPrefs {
   try {
@@ -132,7 +132,7 @@ function writeLocalPrefs(prefs: StudioPrefs): void {
 // Reads skills installed at ~/.hermes/skills/{category}/{skill-name}/SKILL.md
 // Used when the Hermes gateway doesn't expose /api/skills.
 
-const LOCAL_SKILLS_DIR = path.join(os.homedir(), '.hermes', 'skills')
+const LOCAL_SKILLS_DIR = path.join(hermesHome(), 'skills')
 
 function parseFrontmatter(content: string): { meta: Record<string, unknown>; body: string } {
   const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/)

--- a/src/routes/api/skills/install.ts
+++ b/src/routes/api/skills/install.ts
@@ -8,10 +8,11 @@ import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../server/auth-middleware'
 import { hermesHome } from '../../../server/hermes-home'
 import {
-  HERMES_API,
-  ensureGatewayProbed,
-  getCapabilities,
-} from '../../../server/gateway-capabilities'
+    HERMES_API,
+    authHeaders,
+    ensureGatewayProbed,
+    getCapabilities,
+  } from '../../../server/gateway-capabilities'
 
 const execFileAsync = promisify(execFile)
 
@@ -205,7 +206,7 @@ export const Route = createFileRoute('/api/skills/install')({
             try {
               const res = await fetch(`${HERMES_API}/api/skills/install`, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: { ...authHeaders(), 'Content-Type': 'application/json' },
                 body: JSON.stringify({ skillId }),
                 signal: AbortSignal.timeout(30_000),
               })

--- a/src/routes/api/skills/install.ts
+++ b/src/routes/api/skills/install.ts
@@ -6,6 +6,7 @@ import { promisify } from 'node:util'
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../server/auth-middleware'
+import { hermesHome } from '../../../server/hermes-home'
 import {
   HERMES_API,
   ensureGatewayProbed,
@@ -170,7 +171,7 @@ export const Route = createFileRoute('/api/skills/install')({
           }
 
           const source = (body.source || '').trim()
-          const skillsBase = path.join(os.homedir(), '.hermes', 'skills')
+          const skillsBase = path.join(hermesHome(), 'skills')
 
           // ── Strategy 1: skillsmp / skills-sh — download from GitHub ─────────
           if (source === 'skillsmp' || source === 'skills-sh') {
@@ -219,10 +220,10 @@ export const Route = createFileRoute('/api/skills/install')({
           // ── Strategy 3: clawhub CLI ───────────────────────────────────────
           const clawhubAvailable = await isBinaryAvailable('clawhub')
           if (clawhubAvailable) {
-            const hermesHome = path.join(os.homedir(), '.hermes')
+            const home = hermesHome()
             await execFileAsync(
               'clawhub',
-              ['install', skillId, '--workdir', hermesHome, '--dir', 'skills'],
+              ['install', skillId, '--workdir', home, '--dir', 'skills'],
               {
                 cwd: os.homedir(),
                 timeout: 120_000,

--- a/src/routes/api/skills/settings.ts
+++ b/src/routes/api/skills/settings.ts
@@ -4,15 +4,14 @@
  * The skillsmpApiKey is never returned in plaintext — only a masked preview.
  */
 import fs from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../server/auth-middleware'
+import { hermesHome } from '../../../server/hermes-home'
 
 const SETTINGS_PATH = path.join(
-  os.homedir(),
-  '.hermes',
+  hermesHome(),
   'skills',
   '.studio-settings.json',
 )

--- a/src/routes/api/skills/uninstall.ts
+++ b/src/routes/api/skills/uninstall.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../server/auth-middleware'
+import { hermesHome } from '../../../server/hermes-home'
 
 export const Route = createFileRoute('/api/skills/uninstall')({
   server: {
@@ -21,7 +21,7 @@ export const Route = createFileRoute('/api/skills/uninstall')({
               { status: 400 },
             )
 
-          const skillsBase = path.join(os.homedir(), '.hermes', 'skills')
+          const skillsBase = path.join(hermesHome(), 'skills')
           const skillPath = path.join(skillsBase, skillId)
 
           // Path traversal guard — resolved path must be within skills dir

--- a/src/routes/api/workspace.ts
+++ b/src/routes/api/workspace.ts
@@ -2,13 +2,13 @@
  * Phase 2.6: Workspace detection API
  * Auto-detects workspace from Hermes config, env, or default paths
  */
-import os from 'node:os'
 import path from 'node:path'
 import fs from 'node:fs/promises'
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import { getProfileWorkspaceRoot } from '../../server/profiles-browser'
+import { hermesHome } from '../../server/hermes-home'
 
 function extractFolderName(fullPath: string): string {
   const parts = fullPath.replace(/\\/g, '/').split('/')
@@ -61,7 +61,7 @@ async function detectWorkspace(savedPath?: string): Promise<{
   }
 
   // Priority 3: Default Hermes workspace path
-  const defaultPath = path.join(os.homedir(), '.hermes')
+  const defaultPath = hermesHome()
   const defaultValid = await isValidDirectory(defaultPath)
   if (defaultValid) {
     return {
@@ -73,7 +73,7 @@ async function detectWorkspace(savedPath?: string): Promise<{
   }
 
   // Priority 4: Hermes home directory
-  const hermesDir = path.join(os.homedir(), '.hermes')
+  const hermesDir = hermesHome()
   const hermesDirValid = await isValidDirectory(hermesDir)
   if (hermesDirValid) {
     return {

--- a/src/screens/chat/components/chat-composer.tsx
+++ b/src/screens/chat/components/chat-composer.tsx
@@ -118,8 +118,6 @@ type ModelSwitchNotice = {
   retryProvider?: string
 }
 
-const HERMES_API_URL = process.env.HERMES_API_URL || 'http://127.0.0.1:8642'
-
 function readModelText(value: unknown): string {
   return typeof value === 'string' ? value.trim() : ''
 }
@@ -159,32 +157,42 @@ async function fetchModels(): Promise<{
   providerLabels?: Record<string, string>
   providers?: Array<HermesProviderOption>
 }> {
-  // Prefer Hermes' current provider models; fetch other providers lazily if needed.
+  // Prefer Hermes' full provider/model inventory (dashboard picker endpoint);
+  // fall back to /v1/models when the gateway lacks it.
   try {
-    const richRes = await fetch('/api/hermes-proxy/api/available-models')
+    const richRes = await fetch('/api/hermes-proxy/api/model/options')
     if (richRes.ok) {
-      const richData = (await richRes.json()) as HermesAvailableModelsResponse
+      const richData = (await richRes.json()) as {
+        provider?: string
+        model?: string
+        providers?: Array<{
+          slug: string
+          name: string
+          authenticated?: boolean
+          models?: Array<string>
+        }>
+      }
+      const currentProvider = readModelText(richData.provider)
+      const currentProviderEntry = (richData.providers || []).find(
+        (p) => p.slug === currentProvider,
+      )
       const authenticatedProviders = (richData.providers || []).filter(
         (p) => p.authenticated,
       )
-      const configuredProviders = authenticatedProviders.map((p) => p.id)
+      const configuredProviders = authenticatedProviders.map((p) => p.slug)
       const providerLabels = authenticatedProviders.reduce<
         Record<string, string>
       >((acc, provider) => {
-        acc[provider.id] = provider.label || provider.id
+        acc[provider.slug] = provider.name || provider.slug
         return acc
       }, {})
-      const currentProvider = readModelText(richData.provider)
-      let models = (richData.models || []).map((model) => ({
-        id: model.id,
-        name: model.id,
-        provider:
-          ((model as Record<string, unknown>).provider as string) ||
-          currentProvider ||
-          undefined,
+      let models = (currentProviderEntry?.models ?? []).map((id) => ({
+        id,
+        name: id,
+        provider: currentProvider || undefined,
       }))
 
-      // If gateway returns no models, try /v1/models as fallback
+      // If inventory has no models for the current provider, try /v1/models
       if (models.length === 0) {
         try {
           const fallbackRes = await fetch('/api/hermes-proxy/v1/models')
@@ -211,20 +219,11 @@ async function fetchModels(): Promise<{
 
       // Always include current configured model so it appears in the list
       if (currentProvider && models.length === 0) {
-        // Fetch current model from config
-        try {
-          const cfgRes = await fetch('/api/hermes-proxy/api/config')
-          if (cfgRes.ok) {
-            const cfg = (await cfgRes.json()) as Record<string, unknown>
-            const cfgModel = readModelText(cfg.model)
-            if (cfgModel) {
-              models = [
-                { id: cfgModel, name: cfgModel, provider: currentProvider },
-              ]
-            }
-          }
-        } catch {
-          /* ignore */
+        const configured = readModelText(richData.model)
+        if (configured) {
+          models = [
+            { id: configured, name: configured, provider: currentProvider },
+          ]
         }
       }
 
@@ -234,14 +233,19 @@ async function fetchModels(): Promise<{
         configuredProviders,
         currentProvider,
         providerLabels,
-        providers: authenticatedProviders,
+        providers: authenticatedProviders.map((p) => ({
+          id: p.slug,
+          label: p.name,
+          authenticated: Boolean(p.authenticated),
+        })),
       }
     }
   } catch {
     // Fall back to /v1/models
   }
 
-  const response = await fetch(`${HERMES_API_URL}/v1/models`)
+  // Route through the studio proxy so the gateway token is attached server-side.
+  const response = await fetch('/api/hermes-proxy/v1/models')
   if (!response.ok) {
     throw new Error(`Hermes models request failed (${response.status})`)
   }

--- a/src/screens/settings/providers-screen.tsx
+++ b/src/screens/settings/providers-screen.tsx
@@ -12,20 +12,16 @@ import { ProviderIcon } from './components/provider-icon'
 import { ProviderWizard } from './components/provider-wizard'
 import type { ModelCatalogEntry } from '@/lib/model-types'
 import type { ProviderSummaryForEdit } from './components/provider-wizard'
-import BackendUnavailableState from '@/components/backend-unavailable-state'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { toast } from '@/components/ui/toast'
-import { getUnavailableReason } from '@/lib/feature-gates'
-import { useFeatureAvailable } from '@/hooks/use-feature-available'
 import {
   getProviderDisplayName,
   getProviderInfo,
   normalizeProviderId,
 } from '@/lib/provider-catalog'
-import { getConfig, patchConfig } from '@/server/hermes-api'
 import { cn } from '@/lib/utils'
 
 /**
@@ -76,15 +72,65 @@ type ProvidersScreenProps = {
 
 type HermesConfig = Record<string, unknown>
 
-type ConfigQueryResponse = {
-  ok?: boolean
-  payload?: HermesConfig
-  error?: string
-}
-
 type ConfigPatchResponse = {
   ok?: boolean
   error?: string
+}
+
+type HermesConfigResponse = {
+  ok?: boolean
+  config?: HermesConfig
+  error?: string
+}
+
+/** Read the local ~/.hermes/config.yaml via the studio's own config route. */
+async function fetchLocalConfig(): Promise<HermesConfig> {
+  const response = await fetch('/api/hermes-config')
+  const payload = (await response
+    .json()
+    .catch(() => ({}))) as HermesConfigResponse
+  if (!response.ok || payload.ok === false) {
+    throw new Error(payload.error || `HTTP ${response.status}`)
+  }
+  return payload.config ?? {}
+}
+
+/** Persist a config patch to ~/.hermes/config.yaml via the local config route. */
+async function saveLocalConfig(config: Record<string, unknown>): Promise<void> {
+  const response = await fetch('/api/hermes-config', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ config }),
+  })
+  const payload = (await response
+    .json()
+    .catch(() => ({}))) as ConfigPatchResponse
+  if (!response.ok || payload.ok === false) {
+    throw new Error(payload.error || `HTTP ${response.status}`)
+  }
+}
+
+/** Build a nested object from a dot-path, e.g. 'agents.defaults.contextTokens'. */
+function setByPath(
+  target: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): Record<string, unknown> {
+  const parts = path.split('.').filter(Boolean)
+  let node = target
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    const key = parts[i]
+    if (
+      typeof node[key] !== 'object' ||
+      node[key] === null ||
+      Array.isArray(node[key])
+    ) {
+      node[key] = {}
+    }
+    node = node[key] as Record<string, unknown>
+  }
+  node[parts[parts.length - 1]] = value
+  return target
 }
 
 type SelectOption = {
@@ -999,7 +1045,7 @@ function ActiveModelCard({
 
   const configQuery = useQuery({
     queryKey: ['hermes', 'active-config'],
-    queryFn: getConfig,
+    queryFn: fetchLocalConfig,
   })
 
   const saveMutation = useMutation({
@@ -1039,7 +1085,7 @@ function ActiveModelCard({
           }
         : null
 
-      await patchConfig(patch)
+      await saveLocalConfig(patch)
     },
     onSuccess: async () => {
       await Promise.all([
@@ -1386,7 +1432,6 @@ function ProviderManagementSection(props: {
 
 export function ProvidersScreen({ embedded = false }: ProvidersScreenProps) {
   const queryClient = useQueryClient()
-  const configAvailable = useFeatureAvailable('config')
   const [activeTab, setActiveTab] = useState<SettingsTabId>('providers')
   const [search, setSearch] = useState('')
   const [draftValues, setDraftValues] = useState<Record<string, string>>({})
@@ -1400,31 +1445,20 @@ export function ProvidersScreen({ embedded = false }: ProvidersScreenProps) {
     queryFn: fetchModels,
     refetchInterval: 60_000,
     retry: false,
-    enabled: configAvailable,
   })
 
   const configQuery = useQuery({
     queryKey: ['hermes', 'config'],
-    queryFn: async () => {
-      const response = await fetch('/api/config-get')
-      const payload = (await response
-        .json()
-        .catch(() => ({}))) as ConfigQueryResponse
-      if (!response.ok || payload.ok === false) {
-        throw new Error(payload.error || `HTTP ${response.status}`)
-      }
-      return payload.payload ?? {}
-    },
+    queryFn: fetchLocalConfig,
     retry: 1,
-    enabled: configAvailable,
   })
 
   const saveMutation = useMutation({
     mutationFn: async ({ path, value }: SaveSettingPayload) => {
-      const response = await fetch('/api/config-patch', {
-        method: 'POST',
+      const response = await fetch('/api/hermes-config', {
+        method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ path, value }),
+        body: JSON.stringify({ config: setByPath({}, path, value) }),
       })
       const payload = (await response
         .json()
@@ -1553,21 +1587,6 @@ export function ProvidersScreen({ embedded = false }: ProvidersScreenProps) {
   }
 
   const totalSearchMatches = filteredSettings.length
-
-  if (!configAvailable) {
-    return (
-      <div
-        className={cn(
-          embedded ? 'h-full bg-[var(--theme-bg)]' : 'min-h-full bg-[var(--theme-bg)]',
-        )}
-      >
-        <BackendUnavailableState
-          feature="Provider Setup"
-          description={getUnavailableReason('config')}
-        />
-      </div>
-    )
-  }
 
   return (
     <div

--- a/src/server/event-store.ts
+++ b/src/server/event-store.ts
@@ -431,3 +431,20 @@ export function getLatestSeq(sessionKey: string): number {
     return 0
   }
 }
+
+/**
+ * Close the underlying SQLite handle. Needed on Windows so temp-dir
+ * cleanup in tests can delete the database file (open files can't be
+ * removed there). Safe to call anytime; a later call reopens the DB.
+ */
+export function closeEventStore(): void {
+  if (_db) {
+    try {
+      _db.close()
+    } catch {
+      // ignore
+    }
+    _db = null
+    _initAttempted = false
+  }
+}

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -71,7 +71,7 @@ let lastLoggedSummary = ''
 /** Optional bearer token for authenticated endpoints. */
 export const BEARER_TOKEN = process.env.HERMES_API_TOKEN || ''
 
-function authHeaders(): Record<string, string> {
+export function authHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
 }
 

--- a/src/server/hermes-agent.ts
+++ b/src/server/hermes-agent.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
-import { homedir } from 'node:os'
+import { hermesHome } from './hermes-home'
 
 const HERMES_HEALTH_TIMEOUT_MS = 2_000
 const HERMES_START_PORT = 8642
@@ -24,7 +24,7 @@ export type StartHermesAgentResult =
  * Silently returns {} if the file doesn't exist or can't be parsed.
  */
 function readHermesEnv(): Record<string, string> {
-  const envPath = join(homedir(), '.hermes', '.env')
+  const envPath = join(hermesHome(), '.env')
   try {
     const raw = readFileSync(envPath, 'utf-8')
     const result: Record<string, string> = {}

--- a/src/server/hermes-api.ts
+++ b/src/server/hermes-api.ts
@@ -117,10 +117,11 @@ export async function listSessions(
   limit = 50,
   offset = 0,
 ): Promise<Array<HermesSession>> {
-  const resp = await hermesGet<{ items: Array<HermesSession>; total: number }>(
-    `/api/sessions?limit=${limit}&offset=${offset}`,
-  )
-  return resp.items
+  const resp = await hermesGet<{
+    items?: Array<HermesSession>
+    data?: Array<HermesSession>
+  }>(`/api/sessions?limit=${limit}&offset=${offset}`)
+  return resp.items ?? resp.data ?? []
 }
 
 export async function getSession(sessionId: string): Promise<HermesSession> {
@@ -160,10 +161,11 @@ export async function deleteSession(sessionId: string): Promise<void> {
 export async function getMessages(
   sessionId: string,
 ): Promise<Array<HermesMessage>> {
-  const resp = await hermesGet<{ items: Array<HermesMessage>; total: number }>(
-    `/api/sessions/${sessionId}/messages`,
-  )
-  return resp.items
+  const resp = await hermesGet<{
+    items?: Array<HermesMessage>
+    data?: Array<HermesMessage>
+  }>(`/api/sessions/${sessionId}/messages`)
+  return resp.items ?? resp.data ?? []
 }
 
 export async function searchSessions(

--- a/src/server/hermes-home.ts
+++ b/src/server/hermes-home.ts
@@ -1,0 +1,12 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * Resolve the Hermes home dir, mirroring the agent's own resolution
+ * (hermes_cli/_startup_fast.py `_resolved_home`): HERMES_HOME env wins,
+ * otherwise ~/.hermes. On Windows the real home is %LOCALAPPDATA%\hermes
+ * which the user sets via the HERMES_HOME user env var.
+ */
+export function hermesHome(): string {
+  return process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes')
+}

--- a/src/server/knowledge-browser.ts
+++ b/src/server/knowledge-browser.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import YAML from 'yaml'
+import { hermesHome } from './hermes-home'
 
 export type WikiPageMeta = {
   path: string
@@ -115,8 +116,8 @@ function extractWikilinks(content: string): Array<string> {
 
 export function getKnowledgeRoot(): string {
   if (process.env.KNOWLEDGE_DIR) return path.resolve(process.env.KNOWLEDGE_DIR)
-  const hermesHome = path.join(os.homedir(), '.hermes')
-  const hermesKnowledge = path.join(hermesHome, 'knowledge')
+  const hermesRoot = hermesHome()
+  const hermesKnowledge = path.join(hermesRoot, 'knowledge')
   if (fs.existsSync(hermesKnowledge)) return hermesKnowledge
   const homeKnowledge = path.join(os.homedir(), 'knowledge', 'wiki')
   if (fs.existsSync(homeKnowledge)) return homeKnowledge

--- a/src/server/memory-browser.ts
+++ b/src/server/memory-browser.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
+import { hermesHome } from './hermes-home'
 
 export type MemoryFileMeta = {
   path: string
@@ -24,7 +24,7 @@ function isBrowserMemoryPath(relativePath: string): boolean {
 }
 
 function normalizeWorkspaceRoot(): string {
-  return path.join(os.homedir(), '.hermes')
+  return hermesHome()
 }
 
 export function getMemoryWorkspaceRoot(): string {

--- a/src/server/profiles-browser.ts
+++ b/src/server/profiles-browser.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
-import os from 'node:os'
 import path from 'node:path'
 import YAML from 'yaml'
+import { hermesHome } from './hermes-home'
 
 export type ProfileSummary = {
   name: string
@@ -28,7 +28,7 @@ export type ProfileDetail = {
 }
 
 function getHermesRoot(): string {
-  return path.join(os.homedir(), '.hermes')
+  return hermesHome()
 }
 
 export function getProfilesRoot(): string {

--- a/src/server/run-store.ts
+++ b/src/server/run-store.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
-import { homedir } from 'node:os'
 import path from 'node:path'
+import { hermesHome } from './hermes-home'
 
 export type PersistedRunToolCall = {
   id: string
@@ -33,7 +33,7 @@ export type PersistedRunState = {
   errorMessage?: string
 }
 
-const RUNS_ROOT = path.join(homedir(), '.hermes', 'webui-mvp', 'runs')
+const RUNS_ROOT = path.join(hermesHome(), 'webui-mvp', 'runs')
 
 function encodeSessionKey(sessionKey: string): string {
   return encodeURIComponent(sessionKey || 'main')

--- a/src/test/analytics.test.ts
+++ b/src/test/analytics.test.ts
@@ -11,8 +11,11 @@ beforeEach(() => {
   vi.resetModules()
 })
 
-afterEach(() => {
+afterEach(async () => {
   vi.restoreAllMocks()
+  // Close the sqlite handle first — Windows can't delete an open file.
+  const store = await import('@/server/event-store')
+  store.closeEventStore()
   rmSync(tmpDir, { recursive: true, force: true })
 })
 

--- a/src/test/event-store.test.ts
+++ b/src/test/event-store.test.ts
@@ -11,8 +11,11 @@ beforeEach(() => {
   vi.resetModules()
 })
 
-afterEach(() => {
+afterEach(async () => {
   vi.restoreAllMocks()
+  // Close the sqlite handle first — Windows can't delete an open file.
+  const store = await import('@/server/event-store')
+  store.closeEventStore()
   rmSync(tmpDir, { recursive: true, force: true })
 })
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -426,12 +426,10 @@ const config = defineConfig(({ mode, command }) => {
           ws: true,
           rewrite: (path) => path.replace(/^\/ws-hermes/, ''),
         },
-        // REST API proxy: API proxy for Hermes backend
-        '/api/hermes-proxy': {
-          target: proxyTarget,
-          changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/api\/hermes-proxy/, ''),
-        },
+        // NOTE: /api/hermes-proxy is intentionally NOT proxied here — the
+        // TanStack route src/routes/api/hermes-proxy/$.ts handles it and adds
+        // the gateway bearer token server-side (a raw vite proxy can't attach
+        // the credential the browser doesn't hold).
         '/hermes-ui': {
           target: proxyTarget,
           changeOrigin: true,
@@ -468,79 +466,14 @@ const config = defineConfig(({ mode, command }) => {
         },
         configureServer(server) {
           server.middlewares.use(async (req, res, next) => {
+            // frame-ancestors can't be expressed in a <meta> CSP, so send the
+            // equivalent clickjacking guard as a real HTTP header.
+            res.setHeader('X-Frame-Options', 'DENY')
             const requestPath = req.url?.split('?')[0]
             if (req.method === 'GET' && requestPath === '/api/healthcheck') {
               res.statusCode = 200
               res.setHeader('content-type', 'application/json')
               res.end(JSON.stringify({ ok: true }))
-              return
-            }
-
-            // Portable-aware health check — returns ok if any chat backend is available
-            if (
-              req.method === 'GET' &&
-              requestPath === '/api/connection-status'
-            ) {
-              try {
-                // Check for enhanced Hermes gateway first (has /api/sessions)
-                const [modelsRes, sessionsRes] = await Promise.all([
-                  fetch(`${hermesApiUrl}/v1/models`, {
-                    signal: AbortSignal.timeout(3000),
-                  }).catch(() => null),
-                  fetch(`${hermesApiUrl}/api/sessions?limit=1`, {
-                    signal: AbortSignal.timeout(3000),
-                  }).catch(() => null),
-                ])
-                const hasModels = modelsRes?.ok ?? false
-                const hasSessions = sessionsRes?.ok ?? false
-                if (hasModels && hasSessions) {
-                  res.statusCode = 200
-                  res.setHeader('content-type', 'application/json')
-                  res.end(
-                    JSON.stringify({
-                      ok: true,
-                      mode: 'enhanced',
-                      backend: hermesApiUrl,
-                    }),
-                  )
-                  return
-                }
-                if (hasModels) {
-                  res.statusCode = 200
-                  res.setHeader('content-type', 'application/json')
-                  res.end(
-                    JSON.stringify({
-                      ok: true,
-                      mode: 'portable',
-                      backend: hermesApiUrl,
-                    }),
-                  )
-                  return
-                }
-                // Fall back to /health for full Hermes backends
-                const healthRes = await fetch(`${hermesApiUrl}/health`, {
-                  signal: AbortSignal.timeout(3000),
-                })
-                res.statusCode = healthRes.ok ? 200 : 502
-                res.setHeader('content-type', 'application/json')
-                res.end(
-                  JSON.stringify({
-                    ok: healthRes.ok,
-                    mode: 'enhanced',
-                    backend: hermesApiUrl,
-                  }),
-                )
-              } catch {
-                res.statusCode = 502
-                res.setHeader('content-type', 'application/json')
-                res.end(
-                  JSON.stringify({
-                    ok: false,
-                    mode: 'disconnected',
-                    backend: hermesApiUrl,
-                  }),
-                )
-              }
               return
             }
 


### PR DESCRIPTION
## Summary
Wiring fixes to make Hermes Studio work correctly against the Hermes gateway **v0.18+ / v0.20** `api_server` (the aiohttp platform). The studio was built against the older FastAPI `webapi` surface, so several features degraded or broke on current gateways.

## Changes (7 commits)
1. **API envelopes** — `listSessions`/`getMessages` now accept the gateway's OpenAI-style `{object:'list', data:[...]}` responses (were expecting `{items}` → `/api/history` crashed with `undefined.slice`).
2. **HERMES_HOME resolution** — new `src/server/hermes-home.ts` (`HERMES_HOME` env, fallback `~/.hermes`) swept across 17 server files that hardcoded `~/.hermes`. On Windows (`%LOCALAPPDATA%\hermes`) the UI previously read an empty/wrong home (config, skills, memories).
3. **Config as a local feature** — the gateway has no `/api/config`, so the `config` capability probe is false and "Hermes Agent Settings" rendered "Not available on this backend". Mark `config` available in `feature-gates` + `useFeatureAvailable`, wire providers/settings screens to the local `/api/hermes-config` route, and make MCP servers GET read local `config.yaml`.
4. **Model pickers** — composer + settings called dead `/api/available-models`; now use `/api/model/options` (the dashboard picker inventory) so the dropdown lists the provider's real models.
5. **Dev proxy shadowing + CSP** — the vite `server.proxy['/api/hermes-proxy']` shadowed the TanStack route (which attaches the gateway token) → 401s in dev only; removed. CSP: allow `cdn.jsdelivr.net` (Monaco) + Google Fonts; `frame-ancestors` is ignored in `<meta>` so send `X-Frame-Options: DENY` as a real header instead.
6. **Terminal + tests** — guard `fitAddon.fit()` on hidden (inactive) tabs to stop the xterm `reading 'dimensions'` crash; add `closeEventStore()` and call it before `rmSync` in tests so temp sqlite dirs delete on Windows.
7. **Build/deps** — declare missing `katex`, `remark-math`, `rehype-katex`; make the `dev` script cross-platform (drop POSIX `NODE_OPTIONS=...` syntax).

## Verification
- `npm run test` 190/190 green (was 170/20 fail on Windows)
- `npm run build` OK
- Manually verified against a v0.20 gateway: chat, model picker, settings, terminal, files editor, MCP, history, session-status