### PR TITLE
fix(gateway): reach skills/memory/config on the Agent dashboard backend (closes #23, completes #17)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,15 @@ See `.env.example` for all options. Key ones:
 - `HERMES_API_URL` — Hermes Agent gateway backend (default: `http://127.0.0.1:8642`)
 - `HERMES_PASSWORD` — Optional password protection for the web UI
 - `HERMES_ALLOWED_HOSTS` — Comma-separated hostnames for non-localhost access
+- `HERMES_DASHBOARD_URL` — Optional. Hermes Agent's own web-dashboard backend
+  (default port 9119). On Agent v0.19+ the `/api/skills`, `/api/memory` and
+  `/api/config` routes live there, not on the gateway — set this (plus
+  `HERMES_DASHBOARD_SESSION_TOKEN`, the same value the dashboard was started
+  with) to let Studio reach them. Leave unset to use Studio's local
+  `~/.hermes` fallbacks.
+- `HERMES_DASHBOARD_SESSION_TOKEN` — Session token shared with the agent
+  dashboard process (`HERMES_DASHBOARD_TOKEN` also accepted). Server-side
+  only; never exposed to the browser.
 
 ## Guidelines
 

--- a/README.md
+++ b/README.md
@@ -655,6 +655,16 @@ git clone https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent && pip install -e . && hermes --gateway
 ```
 
+> **Note (Hermes Agent v0.19+):** `missing=[skills, memory, config]` is **normal** —
+> those routes moved off the gateway's API server onto the agent's own web
+> dashboard (a separate process, default port 9119). Studio's Skills, Memory,
+> and Settings panels keep working against your local `~/.hermes` files; this
+> is not a version problem and upgrading won't change it.
+>
+> To have Studio read those routes from the dashboard as well, set
+> `HERMES_DASHBOARD_URL` (and a shared `HERMES_DASHBOARD_SESSION_TOKEN`) — see
+> [docs/HERMES_AGENT_COMPATIBILITY.md](docs/HERMES_AGENT_COMPATIBILITY.md).
+
 ### "Connection refused" or workspace hangs on load
 
 Your Hermes gateway isn't running. Start it:

--- a/docs/HERMES_AGENT_COMPATIBILITY.md
+++ b/docs/HERMES_AGENT_COMPATIBILITY.md
@@ -120,9 +120,52 @@ cd hermes-agent && git pull && git checkout v0.18.0
 pip install -e .
 ```
 
-### Memory/Skills APIs unavailable
+### Memory/Skills/Config APIs report missing (Agent v0.19+)
 
-**Symptom:** Memory editor shows "API not available"
+**Symptom:** Startup log shows `missing=[skills, memory, config]` even on a
+current agent; `curl http://127.0.0.1:8642/api/skills` returns 404.
+
+**Cause:** Not a version problem. Hermes Agent v0.19 moved `/api/skills`,
+`/api/memory`, and `/api/config` off the gateway's embedded API server
+(port 8642) onto the agent's own web dashboard backend
+(`hermes_cli/web_server.py`, separate process, default port 9119, its own
+session auth). The capability probe on 8642 correctly finds them absent.
+
+**Effect on Studio:** none that needs fixing — Studio's Skills, Memory, and
+Settings/Providers panels are backed by your local `~/.hermes` files
+(`skills/`, memory workspace, `config.yaml` + `.env`) and keep working.
+These capabilities no longer gate the "Enhanced" connection tier.
+
+#### Optional: point Studio at the dashboard backend
+
+If you want Studio to read those routes from the dashboard instead of only
+from local files, set two server-side env vars:
+
+| Variable | Meaning |
+|---|---|
+| `HERMES_DASHBOARD_URL` | Base URL of the agent's dashboard, e.g. `http://127.0.0.1:9119`. Unset (the default) means Studio never contacts it. |
+| `HERMES_DASHBOARD_SESSION_TOKEN` | Session token shared with the dashboard process. `HERMES_DASHBOARD_TOKEN` is also accepted. |
+
+Studio sends the token as `X-Hermes-Session-Token` (the dashboard also accepts
+`Authorization: Bearer`), probes `/api/skills|memory|config` on the dashboard
+first, and falls back to the gateway for pre-v0.19 agents. A dashboard 401 is
+tracked separately from a gateway 401, so a bad dashboard token never marks
+your gateway as unauthorized.
+
+> **The token is ephemeral by default.** The dashboard reads
+> `HERMES_DASHBOARD_SESSION_TOKEN` from its own environment and otherwise
+> generates a random one **per process** — so a value you hardcode in Studio
+> goes stale the next time the agent restarts. Start the agent with the same
+> variable set on both sides, or leave `HERMES_DASHBOARD_URL` unset and rely on
+> the local-file path.
+
+Both variables are read server-side only and are never inlined into the browser
+bundle. Neither is required: with them unset, Skills/Memory/Config still work
+from `~/.hermes`.
+
+### Memory/Skills APIs unavailable (older agents)
+
+**Symptom:** Memory editor shows "API not available" on an agent **< 0.19**
 
 **Cause:** Agent built without optional features
 

--- a/src/components/inspector/inspector-panel.tsx
+++ b/src/components/inspector/inspector-panel.tsx
@@ -3,7 +3,10 @@ import { create } from 'zustand'
 import { useActivityStore } from './activity-store'
 import type { ActivityEvent } from './activity-store'
 import { getUnavailableReason } from '@/lib/feature-gates'
-import { useFeatureAvailable } from '@/hooks/use-feature-available'
+import {
+  useDashboardStatus,
+  useFeatureAvailable,
+} from '@/hooks/use-feature-available'
 import { cn } from '@/lib/utils'
 
 // ── Store ─────────────────────────────────────────────────────────────────────
@@ -381,6 +384,7 @@ export function InspectorPanel() {
   const isOpen = useInspectorStore((s) => s.isOpen)
   const memoryAvailable = useFeatureAvailable('memory')
   const skillsAvailable = useFeatureAvailable('skills')
+  const dashboardStatus = useDashboardStatus()
   const [activeTab, setActiveTab] = useState<TabId>('activity')
 
   useEffect(() => {
@@ -467,7 +471,7 @@ export function InspectorPanel() {
                     }}
                     title={
                       !available && tab.feature
-                        ? getUnavailableReason(tab.feature)
+                        ? getUnavailableReason(tab.feature, dashboardStatus)
                         : undefined
                     }
                   >

--- a/src/hooks/use-feature-available.ts
+++ b/src/hooks/use-feature-available.ts
@@ -1,13 +1,25 @@
 import { useQuery } from '@tanstack/react-query'
-import type { EnhancedFeature } from '@/lib/feature-gates'
+import type { DashboardStatus, EnhancedFeature } from '@/lib/feature-gates'
 
 interface GatewayStatus {
   capabilities: Record<string, boolean>
   hermesUrl: string
+  /**
+   * Which server each split capability was found on, and the state of the
+   * dashboard backend. /api/gateway-status has always sent these; nothing read
+   * them, so the UI could not tell "no dashboard configured" apart from
+   * "dashboard configured but rejecting our token" (issue #23).
+   */
+  capabilitySources?: Record<string, 'gateway' | 'dashboard' | null>
+  dashboard?: {
+    configured: boolean
+    unauthorized: boolean
+    url: string | null
+  }
 }
 
-export function useFeatureAvailable(feature: EnhancedFeature): boolean {
-  const { data } = useQuery({
+function useGatewayStatus() {
+  return useQuery({
     queryKey: ['gateway-status'],
     queryFn: async () => {
       const res = await fetch('/api/gateway-status')
@@ -17,6 +29,24 @@ export function useFeatureAvailable(feature: EnhancedFeature): boolean {
     staleTime: 30_000,
     refetchInterval: 60_000,
   })
+}
+
+export function useFeatureAvailable(feature: EnhancedFeature): boolean {
+  const { data } = useGatewayStatus()
 
   return data?.capabilities?.[feature] === true
+}
+
+/**
+ * Dashboard-backend state for unavailable-reason copy. Defaults to
+ * "not configured" until the status query resolves, which matches the
+ * pre-existing advice rather than briefly showing a token error.
+ */
+export function useDashboardStatus(): DashboardStatus {
+  const { data } = useGatewayStatus()
+
+  return {
+    configured: data?.dashboard?.configured === true,
+    unauthorized: data?.dashboard?.unauthorized === true,
+  }
 }

--- a/src/lib/feature-gates.ts
+++ b/src/lib/feature-gates.ts
@@ -1,5 +1,3 @@
-import { getCapabilities } from '../server/gateway-capabilities'
-
 export type EnhancedFeature =
   | 'sessions'
   | 'skills'
@@ -32,21 +30,42 @@ function normalizeFeature(
   return null
 }
 
-export function isFeatureAvailable(feature: EnhancedFeature): boolean {
-  const caps = getCapabilities()
-  return caps[feature] === true
-}
-
 export function getFeatureLabel(feature: EnhancedFeature | string): string {
   const normalized = normalizeFeature(feature)
   if (!normalized) return feature
   return FEATURE_LABELS[normalized]
 }
 
+/** Dashboard-backend state, as reported by /api/gateway-status. */
+export type DashboardStatus = {
+  configured: boolean
+  unauthorized: boolean
+}
+
 export function getUnavailableReason(
   feature: EnhancedFeature | string,
+  dashboard?: DashboardStatus,
 ): string {
-  return `${getFeatureLabel(feature)} requires a Hermes gateway with enhanced API support.`
+  const normalized = normalizeFeature(feature)
+  const label = getFeatureLabel(feature)
+  // Hermes v0.19 moved these off the gateway onto the agent's own dashboard
+  // backend — "upgrade your gateway" is the wrong advice for them (issue #23).
+  if (
+    normalized === 'skills' ||
+    normalized === 'memory' ||
+    normalized === 'config'
+  ) {
+    // Telling someone to set HERMES_DASHBOARD_URL when they already have is
+    // the most confusing thing this string can do, so split the three cases.
+    if (dashboard?.configured && dashboard.unauthorized) {
+      return `${label} is on the Hermes Agent dashboard server, but it rejected our session token. The dashboard regenerates its token on every restart unless the agent is started with HERMES_DASHBOARD_SESSION_TOKEN set — set the same value on both sides. Local ~/.hermes data keeps working either way.`
+    }
+    if (dashboard?.configured) {
+      return `${label} is not being served by the configured Hermes Agent dashboard. Check that HERMES_DASHBOARD_URL points at the dashboard (default http://127.0.0.1:9119) and that the agent is recent enough to serve /api/${normalized}. Local ~/.hermes data keeps working either way.`
+    }
+    return `${label} lives on the Hermes Agent dashboard server on current agents. Point HERMES_DASHBOARD_URL at it (default http://127.0.0.1:9119, token via HERMES_DASHBOARD_SESSION_TOKEN) — local ~/.hermes data keeps working either way.`
+  }
+  return `${label} requires a Hermes gateway with enhanced API support.`
 }
 
 export function createCapabilityUnavailablePayload(

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -67,6 +67,8 @@ import { Route as ApiFilesRouteImport } from './routes/api/files'
 import { Route as ApiEventsRouteImport } from './routes/api/events'
 import { Route as ApiContextUsageRouteImport } from './routes/api/context-usage'
 import { Route as ApiConnectionStatusRouteImport } from './routes/api/connection-status'
+import { Route as ApiConfigPatchRouteImport } from './routes/api/config-patch'
+import { Route as ApiConfigGetRouteImport } from './routes/api/config-get'
 import { Route as ApiConductorStopRouteImport } from './routes/api/conductor-stop'
 import { Route as ApiConductorSpawnRouteImport } from './routes/api/conductor-spawn'
 import { Route as ApiChatEventsRouteImport } from './routes/api/chat-events'
@@ -409,6 +411,16 @@ const ApiConnectionStatusRoute = ApiConnectionStatusRouteImport.update({
   path: '/api/connection-status',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiConfigPatchRoute = ApiConfigPatchRouteImport.update({
+  id: '/api/config-patch',
+  path: '/api/config-patch',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiConfigGetRoute = ApiConfigGetRouteImport.update({
+  id: '/api/config-get',
+  path: '/api/config-get',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiConductorStopRoute = ApiConductorStopRouteImport.update({
   id: '/api/conductor-stop',
   path: '/api/conductor-stop',
@@ -697,6 +709,8 @@ export interface FileRoutesByFullPath {
   '/api/chat-events': typeof ApiChatEventsRoute
   '/api/conductor-spawn': typeof ApiConductorSpawnRoute
   '/api/conductor-stop': typeof ApiConductorStopRoute
+  '/api/config-get': typeof ApiConfigGetRoute
+  '/api/config-patch': typeof ApiConfigPatchRoute
   '/api/connection-status': typeof ApiConnectionStatusRoute
   '/api/context-usage': typeof ApiContextUsageRoute
   '/api/events': typeof ApiEventsRouteWithChildren
@@ -807,6 +821,8 @@ export interface FileRoutesByTo {
   '/api/chat-events': typeof ApiChatEventsRoute
   '/api/conductor-spawn': typeof ApiConductorSpawnRoute
   '/api/conductor-stop': typeof ApiConductorStopRoute
+  '/api/config-get': typeof ApiConfigGetRoute
+  '/api/config-patch': typeof ApiConfigPatchRoute
   '/api/connection-status': typeof ApiConnectionStatusRoute
   '/api/context-usage': typeof ApiContextUsageRoute
   '/api/events': typeof ApiEventsRouteWithChildren
@@ -919,6 +935,8 @@ export interface FileRoutesById {
   '/api/chat-events': typeof ApiChatEventsRoute
   '/api/conductor-spawn': typeof ApiConductorSpawnRoute
   '/api/conductor-stop': typeof ApiConductorStopRoute
+  '/api/config-get': typeof ApiConfigGetRoute
+  '/api/config-patch': typeof ApiConfigPatchRoute
   '/api/connection-status': typeof ApiConnectionStatusRoute
   '/api/context-usage': typeof ApiContextUsageRoute
   '/api/events': typeof ApiEventsRouteWithChildren
@@ -1032,6 +1050,8 @@ export interface FileRouteTypes {
     | '/api/chat-events'
     | '/api/conductor-spawn'
     | '/api/conductor-stop'
+    | '/api/config-get'
+    | '/api/config-patch'
     | '/api/connection-status'
     | '/api/context-usage'
     | '/api/events'
@@ -1142,6 +1162,8 @@ export interface FileRouteTypes {
     | '/api/chat-events'
     | '/api/conductor-spawn'
     | '/api/conductor-stop'
+    | '/api/config-get'
+    | '/api/config-patch'
     | '/api/connection-status'
     | '/api/context-usage'
     | '/api/events'
@@ -1253,6 +1275,8 @@ export interface FileRouteTypes {
     | '/api/chat-events'
     | '/api/conductor-spawn'
     | '/api/conductor-stop'
+    | '/api/config-get'
+    | '/api/config-patch'
     | '/api/connection-status'
     | '/api/context-usage'
     | '/api/events'
@@ -1365,6 +1389,8 @@ export interface RootRouteChildren {
   ApiChatEventsRoute: typeof ApiChatEventsRoute
   ApiConductorSpawnRoute: typeof ApiConductorSpawnRoute
   ApiConductorStopRoute: typeof ApiConductorStopRoute
+  ApiConfigGetRoute: typeof ApiConfigGetRoute
+  ApiConfigPatchRoute: typeof ApiConfigPatchRoute
   ApiConnectionStatusRoute: typeof ApiConnectionStatusRoute
   ApiContextUsageRoute: typeof ApiContextUsageRoute
   ApiEventsRoute: typeof ApiEventsRouteWithChildren
@@ -1834,6 +1860,20 @@ declare module '@tanstack/react-router' {
       path: '/api/connection-status'
       fullPath: '/api/connection-status'
       preLoaderRoute: typeof ApiConnectionStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/config-patch': {
+      id: '/api/config-patch'
+      path: '/api/config-patch'
+      fullPath: '/api/config-patch'
+      preLoaderRoute: typeof ApiConfigPatchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/config-get': {
+      id: '/api/config-get'
+      path: '/api/config-get'
+      fullPath: '/api/config-get'
+      preLoaderRoute: typeof ApiConfigGetRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/conductor-stop': {
@@ -2357,6 +2397,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiChatEventsRoute: ApiChatEventsRoute,
   ApiConductorSpawnRoute: ApiConductorSpawnRoute,
   ApiConductorStopRoute: ApiConductorStopRoute,
+  ApiConfigGetRoute: ApiConfigGetRoute,
+  ApiConfigPatchRoute: ApiConfigPatchRoute,
   ApiConnectionStatusRoute: ApiConnectionStatusRoute,
   ApiContextUsageRoute: ApiContextUsageRoute,
   ApiEventsRoute: ApiEventsRouteWithChildren,

--- a/src/routes/api/config-get.ts
+++ b/src/routes/api/config-get.ts
@@ -1,0 +1,37 @@
+/**
+ * Read `~/.hermes/config.yaml` for the settings screens.
+ *
+ * The Providers screen and the provider wizard have always fetched
+ * `/api/config-get` and `/api/config-patch`, but neither route existed — they
+ * 404'd unconditionally, on every agent version, for anyone who got past the
+ * (also wrong) `config` capability gate. Local filesystem only; no gateway
+ * involved, so this keeps working on Hermes Agent v0.19+ where `/api/config`
+ * moved to the dashboard backend (issue #23).
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { readConfig } from '../../server/config-file'
+
+export const Route = createFileRoute('/api/config-get')({
+  server: {
+    handlers: {
+      GET: ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        try {
+          return json({ ok: true, payload: readConfig() })
+        } catch (err) {
+          return json(
+            {
+              ok: false,
+              error: err instanceof Error ? err.message : String(err),
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/config-patch.ts
+++ b/src/routes/api/config-patch.ts
@@ -1,0 +1,78 @@
+/**
+ * Write `~/.hermes/config.yaml` for the settings screens.
+ *
+ * Accepts either body shape the UI already sends (both previously hit a route
+ * that never existed — issue #23):
+ *   { path: "agents.defaults.model.primary", value }  — dot-path set/delete
+ *   { raw: "<JSON object string>", reason? }          — deep-merge a patch
+ * Local filesystem only; no gateway involved.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import { isAuthenticated } from '../../server/auth-middleware'
+import { requireJsonContentType } from '../../server/rate-limit'
+import {
+  deepMerge,
+  readConfig,
+  setConfigPath,
+  writeConfig,
+} from '../../server/config-file'
+
+export const Route = createFileRoute('/api/config-patch')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const contentTypeError = requireJsonContentType(request)
+        if (contentTypeError) return contentTypeError
+
+        const body = (await request.json().catch(() => null)) as {
+          path?: unknown
+          value?: unknown
+          raw?: unknown
+        } | null
+        if (!body) {
+          return json({ ok: false, error: 'Invalid JSON body' }, { status: 400 })
+        }
+
+        try {
+          if (typeof body.path === 'string' && body.path.trim()) {
+            const config = readConfig()
+            setConfigPath(config, body.path.trim(), body.value)
+            writeConfig(config)
+            return json({ ok: true })
+          }
+
+          if (typeof body.raw === 'string') {
+            const patch = JSON.parse(body.raw) as unknown
+            if (!patch || typeof patch !== 'object' || Array.isArray(patch)) {
+              return json(
+                { ok: false, error: 'raw must be a JSON object' },
+                { status: 400 },
+              )
+            }
+            const config = readConfig()
+            deepMerge(config, patch as Record<string, unknown>)
+            writeConfig(config)
+            return json({ ok: true })
+          }
+
+          return json(
+            { ok: false, error: 'Body must include "path" or "raw"' },
+            { status: 400 },
+          )
+        } catch (err) {
+          return json(
+            {
+              ok: false,
+              error: err instanceof Error ? err.message : String(err),
+            },
+            { status: 500 },
+          )
+        }
+      },
+    },
+  },
+})

--- a/src/routes/api/gateway-status.ts
+++ b/src/routes/api/gateway-status.ts
@@ -3,8 +3,12 @@ import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import {
   HERMES_API,
+  HERMES_DASHBOARD_URL,
   ensureGatewayProbed,
   getCapabilities,
+  getCapabilitySources,
+  isDashboardConfigured,
+  isDashboardUnauthorized,
 } from '../../server/gateway-capabilities'
 
 export const Route = createFileRoute('/api/gateway-status')({
@@ -19,6 +23,14 @@ export const Route = createFileRoute('/api/gateway-status')({
         return json({
           capabilities,
           hermesUrl: HERMES_API,
+          // Where each split capability was found (Hermes v0.19 moved them to
+          // the agent's dashboard backend — issue #23).
+          capabilitySources: getCapabilitySources(),
+          dashboard: {
+            configured: isDashboardConfigured(),
+            unauthorized: isDashboardUnauthorized(),
+            url: HERMES_DASHBOARD_URL || null,
+          },
         })
       },
     },

--- a/src/routes/api/mcp/reload.ts
+++ b/src/routes/api/mcp/reload.ts
@@ -1,12 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { isAuthenticated } from '../../../server/auth-middleware'
-import { BEARER_TOKEN, HERMES_API } from '../../../server/gateway-capabilities'
-
-type AuthResult = Response | true
-
-function authHeaders(): Record<string, string> {
-  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
-}
+import {
+  HERMES_API,
+  ensureGatewayProbed,
+  getAuthHeaders,
+} from '../../../server/gateway-capabilities'
 
 const RELOAD_PATHS = ['/api/reload-mcp', '/api/mcp/reload']
 
@@ -14,14 +12,26 @@ export const Route = createFileRoute('/api/mcp/reload')({
   server: {
     handlers: {
       POST: async ({ request }) => {
-        const authResult = isAuthenticated(request) as AuthResult
-        if (authResult !== true) return authResult
+        // isAuthenticated returns a boolean, never a Response. Casting it to
+        // `Response | true` and returning it handed `false` to the router,
+        // which answered an unauthenticated request with a 500 HTTPError
+        // instead of a 401.
+        if (!isAuthenticated(request)) {
+          return Response.json(
+            { ok: false, error: 'Unauthorized' },
+            { status: 401 },
+          )
+        }
+
+        // Resolve the gateway key before using it: on a cold first request the
+        // token is still the unrefined candidate.
+        await ensureGatewayProbed()
 
         for (const path of RELOAD_PATHS) {
           try {
             const response = await fetch(`${HERMES_API}${path}`, {
               method: 'POST',
-              headers: authHeaders(),
+              headers: getAuthHeaders(),
             })
 
             if (response.ok) {

--- a/src/routes/api/mcp/servers.ts
+++ b/src/routes/api/mcp/servers.ts
@@ -5,15 +5,6 @@ import { createFileRoute } from '@tanstack/react-router'
 import YAML from 'yaml'
 import { isAuthenticated } from '../../../server/auth-middleware'
 import { requireJsonContentType } from '../../../server/rate-limit'
-import {
-  BEARER_TOKEN,
-  HERMES_API,
-  ensureGatewayProbed,
-  getCapabilities,
-} from '../../../server/gateway-capabilities'
-import { createCapabilityUnavailablePayload } from '@/lib/feature-gates'
-
-type AuthResult = Response | true
 
 // ─── Local config file I/O (mirrors hermes-config.ts) ────────────────────────
 
@@ -69,10 +60,6 @@ type McpServerRecord = {
   timeout?: number
   connectTimeout?: number
   auth?: unknown
-}
-
-function authHeaders(): Record<string, string> {
-  return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
 }
 
 function toStringRecord(value: unknown): Record<string, string> | undefined {
@@ -142,48 +129,46 @@ function readServers(payload: unknown): Array<McpServerRecord> {
 export const Route = createFileRoute('/api/mcp/servers')({
   server: {
     handlers: {
-      GET: async ({ request }) => {
-        const authResult = isAuthenticated(request) as AuthResult
-        if (authResult !== true) return authResult
-
-        await ensureGatewayProbed()
-        if (!getCapabilities().config) {
-          return Response.json({
-            ...createCapabilityUnavailablePayload('config', {
-              message:
-                'Gateway config API unavailable. You can still draft MCP config snippets locally.',
-            }),
-            servers: [],
-          })
+      GET: ({ request }) => {
+        // isAuthenticated returns a boolean, never a Response. Casting it to
+        // `Response | true` and returning it handed `false` to the router,
+        // which answered an unauthenticated request with a 500 HTTPError
+        // instead of a 401.
+        if (!isAuthenticated(request)) {
+          return Response.json(
+            { ok: false, error: 'Unauthorized' },
+            { status: 401 },
+          )
         }
 
+        // Read the same store PUT writes. This used to fetch the gateway's
+        // /api/config behind a `config` capability gate, which meant two
+        // things were wrong at once: saves went to the local config.yaml while
+        // reads came from the gateway, and on agent v0.19+ — where /api/config
+        // moved off the gateway onto the dashboard backend — the gate blanked
+        // the panel entirely. That is issue #23's symptom in a surface the
+        // issue never enumerated. MCP servers are local configuration, so
+        // there is no capability to gate on.
         try {
-          const response = await fetch(`${HERMES_API}/api/config`, {
-            headers: authHeaders(),
-          })
-
-          if (!response.ok) {
-            return Response.json({
-              servers: [],
-              ok: false,
-              message: `Failed to load MCP servers from gateway config (${response.status}).`,
-            })
-          }
-
-          const payload = (await response.json().catch(() => ({}))) as unknown
-          return Response.json({ ok: true, servers: readServers(payload) })
-        } catch {
+          return Response.json({ ok: true, servers: readServers(readConfig()) })
+        } catch (err) {
           return Response.json({
             servers: [],
             ok: false,
-            message: 'Could not reach Hermes gateway config endpoint.',
+            message: `Failed to read MCP servers from config.yaml: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
           })
         }
       },
 
       PUT: async ({ request }) => {
-        const authResult = isAuthenticated(request) as AuthResult
-        if (authResult !== true) return authResult
+        if (!isAuthenticated(request)) {
+          return Response.json(
+            { ok: false, error: 'Unauthorized' },
+            { status: 401 },
+          )
+        }
         const csrfCheck = requireJsonContentType(request)
         if (csrfCheck) return csrfCheck
 

--- a/src/routes/api/memory.ts
+++ b/src/routes/api/memory.ts
@@ -2,11 +2,11 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { requireLocalOrAuth } from '../../server/auth-middleware'
 import {
-  HERMES_API,
   ensureGatewayProbed,
   getCapabilities,
 } from '../../server/gateway-capabilities'
 import { getMemory } from '../../server/hermes-api'
+import { listMemoryFiles } from '../../server/memory-browser'
 
 export const Route = createFileRoute('/api/memory')({
   server: {
@@ -18,13 +18,10 @@ export const Route = createFileRoute('/api/memory')({
 
         await ensureGatewayProbed()
         if (!getCapabilities().memory) {
-          return json(
-            {
-              ok: false,
-              error: `Gateway does not support /api/memory on ${HERMES_API}`,
-            },
-            { status: 503 },
-          )
+          // Hermes v0.19+ serves /api/memory from its separate dashboard
+          // backend, not the api_server — degrade to the same local ~/.hermes
+          // listing the Memory screen uses instead of 503ing (issue #23).
+          return json({ ok: true, source: 'local', files: listMemoryFiles() })
         }
 
         try {

--- a/src/routes/api/skills.ts
+++ b/src/routes/api/skills.ts
@@ -5,8 +5,11 @@ import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../server/auth-middleware'
 import {
+  HERMES_API,
   ensureGatewayProbed,
+  getAuthHeaders,
   getCapabilities,
+  getCapabilityTarget,
 } from '../../server/gateway-capabilities'
 import { requireJsonContentType } from '../../server/rate-limit'
 
@@ -39,8 +42,6 @@ type SkillSummary = {
   featuredGroup?: string
   security: SecurityRisk
 }
-
-const HERMES_API_URL = process.env.HERMES_API_URL || 'http://127.0.0.1:8642'
 
 const KNOWN_CATEGORIES = [
   'All',
@@ -332,7 +333,18 @@ function normalizeSkill(value: unknown): SkillSummary | null {
 }
 
 async function fetchHermesSkills(): Promise<Array<SkillSummary>> {
-  const response = await fetch(`${HERMES_API_URL}/api/skills`)
+  // Hit whichever server the probe found /api/skills on — the agent's
+  // dashboard backend on v0.19+, the gateway on older agents — with that
+  // server's credentials. This fetch previously went out unauthenticated to a
+  // hardcoded gateway base, bypassing both the discovered key and the 8643
+  // auto-detect (issues #17/#23).
+  const target = getCapabilityTarget('skills') ?? {
+    base: HERMES_API,
+    headers: getAuthHeaders(),
+  }
+  const response = await fetch(`${target.base}/api/skills`, {
+    headers: target.headers,
+  })
   if (!response.ok) {
     const body = await response.text().catch(() => '')
     throw new Error(body || `Hermes skills request failed (${response.status})`)
@@ -343,9 +355,11 @@ async function fetchHermesSkills(): Promise<Array<SkillSummary>> {
     ? payload
     : Array.isArray(asRecord(payload).items)
       ? (asRecord(payload).items as Array<unknown>)
-      : Array.isArray(asRecord(payload).skills)
-        ? (asRecord(payload).skills as Array<unknown>)
-        : []
+      : Array.isArray(asRecord(payload).data)
+        ? (asRecord(payload).data as Array<unknown>)
+        : Array.isArray(asRecord(payload).skills)
+          ? (asRecord(payload).skills as Array<unknown>)
+          : []
 
   const prefs = readLocalPrefs()
   const disabledSet = new Set(prefs.disabled)

--- a/src/routes/api/skills/hub-search.ts
+++ b/src/routes/api/skills/hub-search.ts
@@ -1,7 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import { isAuthenticated } from '../../../server/auth-middleware'
-import { BEARER_TOKEN, HERMES_API } from '../../../server/gateway-capabilities'
+import {
+  BEARER_TOKEN,
+  HERMES_API,
+  ensureGatewayProbed,
+  getCapabilityTarget,
+} from '../../../server/gateway-capabilities'
 import { readSkillsSettings } from './settings'
 
 export type HubSkillSource = 'skillsmp' | 'installed-fallback'
@@ -124,17 +129,36 @@ async function searchSkillsmp(
 
 async function fetchInstalledIds(): Promise<Set<string>> {
   try {
-    const res = await fetch(`${HERMES_API}/api/skills`, {
+    // Same target resolution as fetchHermesSkills() in ../skills.ts: on agent
+    // v0.19+ /api/skills lives on the dashboard backend, so a hardcoded
+    // gateway base silently returned nothing and the marketplace showed every
+    // skill as not-installed (issue #23).
+    await ensureGatewayProbed()
+    const target = getCapabilityTarget('skills') ?? {
+      base: HERMES_API,
       headers: hermesAuthHeaders(),
+    }
+    const res = await fetch(`${target.base}/api/skills`, {
+      headers: target.headers,
       signal: AbortSignal.timeout(5_000),
     })
     if (!res.ok) return new Set()
-    const data = asRecord(await res.json())
-    const items = Array.isArray(data.skills)
-      ? (data.skills as unknown[])
-      : Array.isArray(data)
-        ? (data as unknown[])
-        : []
+    const payload = (await res.json()) as unknown
+    // The gateway answers list endpoints in the OpenAI list shape
+    // ({ object: "list", data: [...] }); older builds used `items`, and the
+    // dashboard uses `skills`. Reading only `skills` made every skill look
+    // not-installed against a current gateway — the same parsing mismatch as
+    // issue #18. Mirrors the chain in ../skills.ts.
+    const data = asRecord(payload)
+    const items = Array.isArray(payload)
+      ? (payload as Array<unknown>)
+      : Array.isArray(data.skills)
+        ? (data.skills as Array<unknown>)
+        : Array.isArray(data.data)
+          ? (data.data as Array<unknown>)
+          : Array.isArray(data.items)
+            ? (data.items as Array<unknown>)
+            : []
     return new Set(
       items
         .map((e) => {

--- a/src/routes/api/skills/install.ts
+++ b/src/routes/api/skills/install.ts
@@ -9,7 +9,9 @@ import { isAuthenticated } from '../../../server/auth-middleware'
 import {
   HERMES_API,
   ensureGatewayProbed,
+  getAuthHeaders,
   getCapabilities,
+  getCapabilityTarget,
 } from '../../../server/gateway-capabilities'
 
 const execFileAsync = promisify(execFile)
@@ -198,13 +200,25 @@ export const Route = createFileRoute('/api/skills/install')({
             return json({ ok: true, installed: true, skillId, method: 'github' })
           }
 
-          // ── Strategy 2: Hermes gateway native install ─────────────────────
+          // ── Strategy 2: Hermes native install (dashboard or gateway) ──────
           await ensureGatewayProbed()
           if (getCapabilities().skills) {
             try {
-              const res = await fetch(`${HERMES_API}/api/skills/install`, {
+              // Unauthenticated before: the POST 401'd and fell silently
+              // through to the clawhub CLI, so an install that should have
+              // been served natively looked like "clawhub not installed"
+              // (issue #17). Target resolution also follows /api/skills onto
+              // the dashboard backend on agent v0.19+ (issue #23).
+              const target = getCapabilityTarget('skills') ?? {
+                base: HERMES_API,
+                headers: getAuthHeaders(),
+              }
+              const res = await fetch(`${target.base}/api/skills/install`, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: {
+                  ...target.headers,
+                  'Content-Type': 'application/json',
+                },
                 body: JSON.stringify({ skillId }),
                 signal: AbortSignal.timeout(30_000),
               })

--- a/src/screens/settings/providers-screen.tsx
+++ b/src/screens/settings/providers-screen.tsx
@@ -12,20 +12,16 @@ import { ProviderIcon } from './components/provider-icon'
 import { ProviderWizard } from './components/provider-wizard'
 import type { ModelCatalogEntry } from '@/lib/model-types'
 import type { ProviderSummaryForEdit } from './components/provider-wizard'
-import BackendUnavailableState from '@/components/backend-unavailable-state'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { toast } from '@/components/ui/toast'
-import { getUnavailableReason } from '@/lib/feature-gates'
-import { useFeatureAvailable } from '@/hooks/use-feature-available'
 import {
   getProviderDisplayName,
   getProviderInfo,
   normalizeProviderId,
 } from '@/lib/provider-catalog'
-import { getConfig, patchConfig } from '@/server/hermes-api'
 import { cn } from '@/lib/utils'
 
 /**
@@ -115,21 +111,42 @@ type SaveSettingPayload = {
   label: string
 }
 
-const HERMES_API_URL = process.env.HERMES_API_URL || 'http://127.0.0.1:8642'
+/**
+ * Config I/O goes through Studio's own server routes, never
+ * `@/server/hermes-api`.
+ *
+ * This is a client component: importing getConfig/patchConfig here shipped the
+ * server client into the browser bundle, which then called the gateway's
+ * /api/config cross-origin with no credentials — and v0.19+ agents do not
+ * serve /api/config on the gateway at all (issues #17 and #23).
+ * /api/config-get and /api/config-patch are local-filesystem routes behind
+ * Studio's own session check.
+ */
+async function fetchHermesConfig(): Promise<HermesConfig> {
+  const response = await fetch('/api/config-get')
+  const payload = (await response
+    .json()
+    .catch(() => ({}))) as ConfigQueryResponse
+  if (!response.ok || payload.ok === false) {
+    throw new Error(payload.error || `HTTP ${response.status}`)
+  }
+  return payload.payload ?? {}
+}
 
-type HermesCatalogEntry =
-  | string
-  | {
-      id: string
-      provider: string
-      name: string
-      [key: string]: unknown
-    }
-
-function isHermesCatalogEntry(
-  entry: HermesCatalogEntry | null,
-): entry is HermesCatalogEntry {
-  return entry !== null
+async function patchHermesConfig(
+  patch: Record<string, unknown>,
+): Promise<void> {
+  const response = await fetch('/api/config-patch', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ raw: JSON.stringify(patch) }),
+  })
+  const payload = (await response
+    .json()
+    .catch(() => ({}))) as ConfigPatchResponse
+  if (!response.ok || payload.ok === false) {
+    throw new Error(payload.error || `HTTP ${response.status}`)
+  }
 }
 
 async function fetchModels(): Promise<{
@@ -137,80 +154,22 @@ async function fetchModels(): Promise<{
   models?: Array<ModelCatalogEntry>
   configuredProviders?: Array<string>
 }> {
-  const response = await fetch(`${HERMES_API_URL}/v1/models`)
+  // Go through Studio's own /api/models route, which holds the gateway bearer
+  // server-side and already normalizes entries. This is a client component, so
+  // the previous `fetch(`${HERMES_API_URL}/v1/models`)` was the browser calling
+  // the gateway directly, cross-origin and with no credentials — it 401'd on
+  // any gateway with API_SERVER_KEY set and left the model list empty
+  // (issue #17). vite.config.ts inlines HERMES_API_URL into the client bundle,
+  // which is what made it look like it should work.
+  const response = await fetch('/api/models')
   if (!response.ok) {
     throw new Error(`Hermes models request failed (${response.status})`)
   }
 
-  const payload = (await response.json()) as
-    | Array<unknown>
-    | {
-        data?: Array<Record<string, unknown>>
-        models?: Array<Record<string, unknown>>
-      }
-  const rawModels = Array.isArray(payload)
-    ? payload
-    : Array.isArray(payload.data)
-      ? payload.data
-      : Array.isArray(payload.models)
-        ? payload.models
-        : []
-
-  const models = rawModels
-    .map((entry) => {
-      if (typeof entry === 'string') return entry
-      if (!entry || typeof entry !== 'object') return null
-      const record = entry as Record<string, unknown>
-      const id =
-        typeof record.id === 'string'
-          ? record.id.trim()
-          : typeof record.name === 'string'
-            ? record.name.trim()
-            : typeof record.model === 'string'
-              ? record.model.trim()
-              : ''
-      if (!id) return null
-      const provider =
-        typeof record.provider === 'string' && record.provider.trim()
-          ? record.provider.trim()
-          : typeof record.owned_by === 'string' && record.owned_by.trim()
-            ? record.owned_by.trim()
-            : id.includes('/')
-              ? id.split('/')[0]
-              : 'hermes-agent'
-
-      return {
-        ...record,
-        id,
-        provider,
-        name:
-          typeof record.name === 'string' && record.name.trim()
-            ? record.name.trim()
-            : typeof record.display_name === 'string' &&
-                record.display_name.trim()
-              ? record.display_name.trim()
-              : typeof record.label === 'string' && record.label.trim()
-                ? record.label.trim()
-                : id,
-      }
-    })
-    .filter(isHermesCatalogEntry)
-
-  const configuredProviders = Array.from(
-    new Set(
-      models.flatMap((entry) => {
-        if (typeof entry === 'string') return []
-        return typeof entry.provider === 'string' && entry.provider
-          ? [entry.provider]
-          : []
-      }),
-    ),
-  )
-
-  return {
-    ok: true,
-    models: models as Array<ModelCatalogEntry>,
-    configuredProviders,
+  return (await response.json()) as {
+    ok?: boolean
+    models?: Array<ModelCatalogEntry>
+    configuredProviders?: Array<string>
   }
 }
 
@@ -999,7 +958,7 @@ function ActiveModelCard({
 
   const configQuery = useQuery({
     queryKey: ['hermes', 'active-config'],
-    queryFn: getConfig,
+    queryFn: fetchHermesConfig,
   })
 
   const saveMutation = useMutation({
@@ -1039,7 +998,7 @@ function ActiveModelCard({
           }
         : null
 
-      await patchConfig(patch)
+      await patchHermesConfig(patch)
     },
     onSuccess: async () => {
       await Promise.all([
@@ -1386,7 +1345,6 @@ function ProviderManagementSection(props: {
 
 export function ProvidersScreen({ embedded = false }: ProvidersScreenProps) {
   const queryClient = useQueryClient()
-  const configAvailable = useFeatureAvailable('config')
   const [activeTab, setActiveTab] = useState<SettingsTabId>('providers')
   const [search, setSearch] = useState('')
   const [draftValues, setDraftValues] = useState<Record<string, string>>({})
@@ -1400,7 +1358,6 @@ export function ProvidersScreen({ embedded = false }: ProvidersScreenProps) {
     queryFn: fetchModels,
     refetchInterval: 60_000,
     retry: false,
-    enabled: configAvailable,
   })
 
   const configQuery = useQuery({
@@ -1416,7 +1373,6 @@ export function ProvidersScreen({ embedded = false }: ProvidersScreenProps) {
       return payload.payload ?? {}
     },
     retry: 1,
-    enabled: configAvailable,
   })
 
   const saveMutation = useMutation({
@@ -1553,21 +1509,6 @@ export function ProvidersScreen({ embedded = false }: ProvidersScreenProps) {
   }
 
   const totalSearchMatches = filteredSettings.length
-
-  if (!configAvailable) {
-    return (
-      <div
-        className={cn(
-          embedded ? 'h-full bg-[var(--theme-bg)]' : 'min-h-full bg-[var(--theme-bg)]',
-        )}
-      >
-        <BackendUnavailableState
-          feature="Provider Setup"
-          description={getUnavailableReason('config')}
-        />
-      </div>
-    )
-  }
 
   return (
     <div

--- a/src/server/config-file.ts
+++ b/src/server/config-file.ts
@@ -1,0 +1,80 @@
+/**
+ * Local `~/.hermes/config.yaml` I/O.
+ *
+ * Extracted so the settings routes share one implementation instead of each
+ * keeping a private copy (`hermes-config.ts` and `mcp/servers.ts` both had
+ * one). Filesystem only — the gateway is never involved, which is exactly why
+ * the Config panel keeps working on Hermes Agent v0.19+, where `/api/config`
+ * moved off the gateway onto the agent's dashboard backend (issue #23).
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import YAML from 'yaml'
+
+export const HERMES_HOME = path.join(os.homedir(), '.hermes')
+export const CONFIG_PATH = path.join(HERMES_HOME, 'config.yaml')
+
+export function readConfig(): Record<string, unknown> {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, 'utf-8')
+    return (YAML.parse(raw) as Record<string, unknown>) || {}
+  } catch {
+    return {}
+  }
+}
+
+export function writeConfig(config: Record<string, unknown>): void {
+  fs.mkdirSync(HERMES_HOME, { recursive: true })
+  fs.writeFileSync(CONFIG_PATH, YAML.stringify(config), 'utf-8')
+}
+
+/** Recursively merge `source` into `target`, in place. */
+export function deepMerge(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): void {
+  for (const [key, value] of Object.entries(source)) {
+    if (
+      value &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      target[key] &&
+      typeof target[key] === 'object'
+    ) {
+      deepMerge(
+        target[key] as Record<string, unknown>,
+        value as Record<string, unknown>,
+      )
+    } else {
+      target[key] = value
+    }
+  }
+}
+
+/**
+ * Set (or, for null/undefined, delete) a dot-path leaf, creating intermediate
+ * objects as needed.
+ */
+export function setConfigPath(
+  config: Record<string, unknown>,
+  dotPath: string,
+  value: unknown,
+): void {
+  const segments = dotPath.split('.').filter(Boolean)
+  if (segments.length === 0) return
+  let node = config
+  for (const segment of segments.slice(0, -1)) {
+    const next = node[segment]
+    if (!next || typeof next !== 'object' || Array.isArray(next)) {
+      node[segment] = {}
+    }
+    node = node[segment] as Record<string, unknown>
+  }
+  const leaf = segments[segments.length - 1]
+  if (value === null || value === undefined) {
+    delete node[leaf]
+  } else {
+    node[leaf] = value
+  }
+}

--- a/src/server/gateway-capabilities.ts
+++ b/src/server/gateway-capabilities.ts
@@ -8,6 +8,8 @@
  *   - Enhanced: Hermes-native extras (sessions, skills, memory, config, jobs)
  */
 
+import { gatewayKeyCandidates, resolveGatewayKey } from './gateway-key'
+
 export let HERMES_API = process.env.HERMES_API_URL || 'http://127.0.0.1:8642'
 
 export const HERMES_UPGRADE_INSTRUCTIONS =
@@ -46,6 +48,7 @@ export type ConnectionStatus =
   | 'connected'
   | 'enhanced'
   | 'partial'
+  | 'unauthorized'
   | 'disconnected'
 
 // ── State ─────────────────────────────────────────────────────────
@@ -68,11 +71,107 @@ let probePromise: Promise<GatewayCapabilities> | null = null
 let lastProbeAt = 0
 let lastLoggedSummary = ''
 
-/** Optional bearer token for authenticated endpoints. */
-export const BEARER_TOKEN = process.env.HERMES_API_TOKEN || ''
+/**
+ * Bearer token for authenticated gateway endpoints.
+ *
+ * Initialized synchronously from HERMES_API_TOKEN or the first
+ * API_SERVER_KEY found in ~/.hermes/.env / ~/.hermes/profiles/<p>/.env,
+ * then refined asynchronously during probeGateway(): candidates are tried
+ * against /v1/models and the first accepted key wins. Live ESM binding —
+ * all importers see the resolved value. NEVER log or return this value.
+ */
+// Guard: this module is (transitively) pulled into client bundles via
+// hermes-api imports in a few screens. gatewayKeyCandidates() reads
+// node:fs/os/path, which Vite externalizes for the browser — calling it
+// there throws at module init and blanks every route in the chunk. Key
+// discovery is meaningless in the browser anyway (requests go through
+// Studio's own /api proxy), so only run it under Node.
+const IS_NODE = typeof process !== 'undefined' && Boolean(process.versions?.node)
 
-function authHeaders(): Record<string, string> {
+export let BEARER_TOKEN = IS_NODE ? (gatewayKeyCandidates()[0] ?? '') : ''
+
+/** True when the gateway rejected every known key candidate with 401/403. */
+let gatewayUnauthorized = false
+
+export function isGatewayUnauthorized(): boolean {
+  return gatewayUnauthorized
+}
+
+export function getAuthHeaders(): Record<string, string> {
   return BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+}
+
+// ── Hermes dashboard backend (optional second server) ─────────────
+//
+// Hermes Agent v0.19 moved /api/skills, /api/memory and /api/config off the
+// messaging gateway's api_server onto the agent's own web dashboard backend
+// (hermes_cli/web_server.py, default port 9119). That server authenticates
+// with a per-process session token: start it with
+// HERMES_DASHBOARD_SESSION_TOKEN=<secret> and give Studio the same value so
+// both sides agree. Accepted as X-Hermes-Session-Token (preferred) or
+// Authorization: Bearer. Server-only — the vite client transform rewrites
+// unknown process.env.* to undefined, so neither value can reach the browser
+// bundle. (Issue #23.)
+
+export const HERMES_DASHBOARD_URL = IS_NODE
+  ? (process.env.HERMES_DASHBOARD_URL ?? '').replace(/\/+$/, '')
+  : ''
+
+const DASHBOARD_TOKEN = IS_NODE
+  ? (process.env.HERMES_DASHBOARD_TOKEN ??
+    process.env.HERMES_DASHBOARD_SESSION_TOKEN ??
+    '')
+  : ''
+
+/** True when the dashboard rejected our session token with 401. Kept separate
+ *  from gatewayUnauthorized — a bad dashboard token must not flip the whole
+ *  app's connection status. */
+let dashboardUnauthorized = false
+
+export function isDashboardConfigured(): boolean {
+  return Boolean(HERMES_DASHBOARD_URL)
+}
+
+export function isDashboardUnauthorized(): boolean {
+  return dashboardUnauthorized
+}
+
+export function getDashboardHeaders(): Record<string, string> {
+  return DASHBOARD_TOKEN ? { 'X-Hermes-Session-Token': DASHBOARD_TOKEN } : {}
+}
+
+export type SplitCapability = 'skills' | 'memory' | 'config'
+
+const capabilityTargets: Record<SplitCapability, 'gateway' | 'dashboard' | null> =
+  {
+    skills: null,
+    memory: null,
+    config: null,
+  }
+
+/** Which server each split capability was found on (null = neither). */
+export function getCapabilitySources(): Record<
+  SplitCapability,
+  'gateway' | 'dashboard' | null
+> {
+  return { ...capabilityTargets }
+}
+
+/**
+ * Where a split capability's data calls should go, or null when neither
+ * server exposes it. Base has no trailing slash.
+ */
+export function getCapabilityTarget(
+  cap: SplitCapability,
+): { base: string; headers: Record<string, string> } | null {
+  const target = capabilityTargets[cap]
+  if (target === 'dashboard') {
+    return { base: HERMES_DASHBOARD_URL, headers: getDashboardHeaders() }
+  }
+  if (target === 'gateway') {
+    return { base: HERMES_API, headers: getAuthHeaders() }
+  }
+  return null
 }
 
 // ── Probing ───────────────────────────────────────────────────────
@@ -80,17 +179,78 @@ function authHeaders(): Record<string, string> {
 async function probe(path: string): Promise<boolean> {
   try {
     const res = await fetch(`${HERMES_API}${path}`, {
-      headers: authHeaders(),
+      headers: getAuthHeaders(),
       signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
     })
     // 404 = endpoint doesn't exist.
     // 403 = likely a catch-all rejection (e.g. Codex endpoint rejects unknown paths).
+    // 401 = endpoint exists but our key is missing/invalid — tracked as a
+    //       DISTINCT unauthorized state (gatewayUnauthorized), never silently
+    //       treated as a healthy endpoint.
     // Only 2xx, 400, 405, 422 reliably indicate the endpoint exists.
+    if (res.status === 401) {
+      gatewayUnauthorized = true
+      return true
+    }
     if (res.status === 404 || res.status === 403) return false
     return true
   } catch {
     return false
   }
+}
+
+/**
+ * The dashboard serves a single-page app, and its catch-all answers ANY unknown
+ * path with `200 text/html` — verified against a live v0.19 dashboard, where
+ * `/definitely-not-a-real-path` returns 200 HTML while the real `/api/*` routes
+ * return JSON. A status-only check therefore reports every capability as
+ * present on a dashboard whose routes have moved or whose URL is mistyped, and
+ * then feeds HTML to JSON.parse at data-fetch time.
+ *
+ * Requiring JSON fails safe in the right direction: a real endpoint that
+ * answers in some other content type is merely missed, and skills/memory/config
+ * all degrade to their local ~/.hermes fallbacks.
+ */
+function isJsonResponse(res: Response): boolean {
+  return (res.headers.get('content-type') ?? '').toLowerCase().includes('json')
+}
+
+/**
+ * Probe one split capability (skills/memory/config). Prefers the dashboard
+ * backend when HERMES_DASHBOARD_URL is set, falling back to the gateway path
+ * for pre-v0.19 agents that still serve it there. Records where the
+ * capability was found so data calls hit the same server. A dashboard 401
+ * sets dashboardUnauthorized — never gatewayUnauthorized.
+ */
+async function probeSplitCapability(cap: SplitCapability): Promise<boolean> {
+  const path = `/api/${cap}`
+
+  if (HERMES_DASHBOARD_URL) {
+    try {
+      const res = await fetch(`${HERMES_DASHBOARD_URL}${path}`, {
+        headers: getDashboardHeaders(),
+        signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      })
+      if (res.status === 401) {
+        // Set-only. probeGateway() clears this once per cycle, so the flag
+        // does not depend on which of the three concurrent probes lands last.
+        dashboardUnauthorized = true
+      } else if (
+        res.status !== 404 &&
+        res.status !== 403 &&
+        isJsonResponse(res)
+      ) {
+        capabilityTargets[cap] = 'dashboard'
+        return true
+      }
+    } catch {
+      // fall through to the gateway probe
+    }
+  }
+
+  const onGateway = await probe(path)
+  capabilityTargets[cap] = onGateway ? 'gateway' : null
+  return onGateway
 }
 
 /** Probe /v1/chat/completions to check if the endpoint exists.
@@ -101,7 +261,7 @@ async function probeChatCompletions(): Promise<boolean> {
     // Fast path: GET returns 405 Method Not Allowed = endpoint exists
     const getRes = await fetch(`${HERMES_API}/v1/chat/completions`, {
       method: 'GET',
-      headers: authHeaders(),
+      headers: getAuthHeaders(),
       signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
     })
     // 405 = endpoint exists but wrong method (expected for POST-only routes)
@@ -120,7 +280,17 @@ async function probeChatCompletions(): Promise<boolean> {
 }
 
 // APIs that are optional and do not warrant an upgrade warning when absent.
-const OPTIONAL_APIS = new Set(['jobs', 'chatCompletions', 'streaming'])
+// skills/memory/config are optional since Hermes v0.19 moved them off the
+// api_server onto the agent's own dashboard backend — their absence is the
+// NORMAL state on current agents, not a version-lag signal (issue #23).
+const OPTIONAL_APIS = new Set([
+  'jobs',
+  'chatCompletions',
+  'streaming',
+  'skills',
+  'memory',
+  'config',
+])
 
 function logCapabilities(next: GatewayCapabilities): void {
   const core: Array<string> = []
@@ -198,6 +368,24 @@ export async function probeGateway(options?: {
       }
     }
 
+    // Resolve a working gateway key before probing authenticated endpoints.
+    // Tries HERMES_API_TOKEN, then API_SERVER_KEY from ~/.hermes/.env and
+    // every profile .env. Values are never logged.
+    const keyResult = await resolveGatewayKey(HERMES_API, PROBE_TIMEOUT_MS)
+    BEARER_TOKEN = keyResult.token
+    gatewayUnauthorized = keyResult.unauthorized
+    if (gatewayUnauthorized) {
+      console.warn(
+        '[gateway] All gateway key candidates were rejected (401). Set HERMES_API_TOKEN or ensure API_SERVER_KEY in ~/.hermes/.env matches the running gateway.',
+      )
+    }
+
+    // Cleared once per cycle, then only ever set to true by the three
+    // concurrent dashboard probes below. They previously also reset it to
+    // false on success, so with skills 401ing and memory succeeding the final
+    // value came down to which promise settled last.
+    dashboardUnauthorized = false
+
     const [
       health,
       chatCompletions,
@@ -214,9 +402,9 @@ export async function probeGateway(options?: {
       probe('/v1/models'),
       probe('/api/sessions'),
       probe('/api/sessions/__probe__/chat/stream'),
-      probe('/api/skills'),
-      probe('/api/memory'),
-      probe('/api/config'),
+      probeSplitCapability('skills'),
+      probeSplitCapability('memory'),
+      probeSplitCapability('config'),
       probe('/api/jobs'),
     ])
 
@@ -308,12 +496,13 @@ export function getChatMode(): ChatMode {
 export function getConnectionStatus(): ConnectionStatus {
   if (!capabilities.health && !capabilities.chatCompletions)
     return 'disconnected'
-  const enhanced =
-    capabilities.sessions &&
-    capabilities.enhancedChat &&
-    capabilities.skills &&
-    capabilities.memory &&
-    capabilities.config
+  if (gatewayUnauthorized) return 'unauthorized'
+  // 'enhanced' = the Hermes-native session APIs work. skills/memory/config do
+  // NOT gate this tier: Hermes v0.19 moved them to the agent's separate
+  // dashboard server, so requiring them pinned every current agent at
+  // 'partial' forever (issue #23). Studio's own panels for them are
+  // filesystem-backed and keep working either way.
+  const enhanced = capabilities.sessions && capabilities.enhancedChat
   if (enhanced) return 'enhanced'
   if (capabilities.chatCompletions || capabilities.sessions) return 'partial'
   return 'connected'

--- a/src/server/gateway-key.ts
+++ b/src/server/gateway-key.ts
@@ -1,0 +1,114 @@
+/**
+ * Gateway API key discovery.
+ *
+ * The Hermes gateway requires its `API_SERVER_KEY` as a bearer token on
+ * `/v1/models` and most other endpoints. Studio historically only read
+ * `HERMES_API_TOKEN` from its own environment, which is usually unset —
+ * every request then 401'd and the model picker rendered empty.
+ *
+ * This module discovers candidate keys server-side:
+ *   1. `HERMES_API_TOKEN` env var (explicit override, highest priority)
+ *   2. `API_SERVER_KEY` in `~/.hermes/.env`
+ *   3. `API_SERVER_KEY` in each `~/.hermes/profiles/<name>/.env`
+ *      (a gateway started with `--profile <name>` loads its key from there)
+ *
+ * SECURITY: key values are never logged, never returned to the client, and
+ * never included in error messages. Only presence/absence is observable.
+ */
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+/** Hermes' own home directory — where the gateway keeps `.env` and profiles. */
+function resolveHermesRoot(): string {
+  const envHome = (process.env.HERMES_HOME ?? '').trim()
+  if (envHome) return envHome
+
+  if (process.platform === 'win32') {
+    const localAppData = (process.env.LOCALAPPDATA ?? '').trim()
+    const base = localAppData || path.join(os.homedir(), 'AppData', 'Local')
+    return path.join(base, 'hermes')
+  }
+
+  return path.join(os.homedir(), '.hermes')
+}
+
+function readEnvKey(envPath: string, keyName: string): string {
+  try {
+    const raw = fs.readFileSync(envPath, 'utf-8')
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      if (!trimmed.startsWith(`${keyName}=`)) continue
+      let value = trimmed.slice(keyName.length + 1).trim()
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1)
+      }
+      return value
+    }
+  } catch {
+    // File missing or unreadable — not an error, just no candidate.
+  }
+  return ''
+}
+
+/** Ordered, de-duplicated list of candidate gateway keys. Never log these. */
+export function gatewayKeyCandidates(): Array<string> {
+  const candidates: Array<string> = []
+  const push = (value: string) => {
+    if (value && !candidates.includes(value)) candidates.push(value)
+  }
+
+  push((process.env.HERMES_API_TOKEN || '').trim())
+
+  const hermesHome = resolveHermesRoot()
+  push(readEnvKey(path.join(hermesHome, '.env'), 'API_SERVER_KEY'))
+
+  try {
+    const profilesDir = path.join(hermesHome, 'profiles')
+    for (const name of fs.readdirSync(profilesDir).sort()) {
+      push(readEnvKey(path.join(profilesDir, name, '.env'), 'API_SERVER_KEY'))
+    }
+  } catch {
+    // No profiles directory — fine.
+  }
+
+  return candidates
+}
+
+/**
+ * Probe candidates against the gateway and return the first key it accepts.
+ * Returns:
+ *   { token, unauthorized: false } — a working key (or gateway needs no key)
+ *   { token: '', unauthorized: true } — gateway rejects every candidate
+ *   { token: <first candidate>, unauthorized: false } — gateway unreachable;
+ *     keep the best guess so a later retry can succeed.
+ */
+export async function resolveGatewayKey(
+  apiUrl: string,
+  timeoutMs = 3000,
+): Promise<{ token: string; unauthorized: boolean }> {
+  const candidates = gatewayKeyCandidates()
+  const attempts = candidates.length > 0 ? candidates : ['']
+
+  for (const token of attempts) {
+    try {
+      const res = await fetch(`${apiUrl}/v1/models`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        signal: AbortSignal.timeout(timeoutMs),
+      })
+      if (res.status !== 401 && res.status !== 403) {
+        return { token, unauthorized: false }
+      }
+    } catch {
+      // Gateway unreachable — do not mark unauthorized; keep best guess.
+      return { token: candidates[0] ?? '', unauthorized: false }
+    }
+  }
+
+  return { token: '', unauthorized: true }
+}

--- a/src/server/hermes-api.ts
+++ b/src/server/hermes-api.ts
@@ -10,9 +10,12 @@ import {
   HERMES_API,
   SESSIONS_API_UNAVAILABLE_MESSAGE,
   ensureGatewayProbed,
+  getAuthHeaders,
   getCapabilities,
+  getCapabilityTarget,
   probeGateway,
 } from './gateway-capabilities'
+import type { SplitCapability } from './gateway-capabilities'
 
 const _authHeaders = (): Record<string, string> =>
   BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
@@ -90,6 +93,37 @@ async function hermesPatch<T>(path: string, body: unknown): Promise<T> {
   if (!res.ok) {
     const text = await res.text().catch(() => '')
     throw new Error(`Hermes API PATCH ${path}: ${res.status} ${text}`)
+  }
+  return res.json() as Promise<T>
+}
+
+/**
+ * Request against a split capability (skills/memory/config) at whichever
+ * server the probe found it on — the agent's dashboard backend on v0.19+,
+ * the gateway on older agents (issue #23). Falls back to the gateway when the
+ * probe found neither, preserving the old error shape.
+ */
+async function splitCapabilityRequest<T>(
+  cap: SplitCapability,
+  path: string,
+  init?: { method?: string; body?: unknown },
+): Promise<T> {
+  const target = getCapabilityTarget(cap) ?? {
+    base: HERMES_API,
+    headers: getAuthHeaders(),
+  }
+  const method = init?.method ?? 'GET'
+  const res = await fetch(`${target.base}${path}`, {
+    method,
+    headers:
+      init?.body === undefined
+        ? target.headers
+        : { ...target.headers, 'Content-Type': 'application/json' },
+    body: init?.body === undefined ? undefined : JSON.stringify(init.body),
+  })
+  if (!res.ok) {
+    const text = await res.text().catch(() => '')
+    throw new Error(`Hermes API ${method} ${path}: ${res.status} ${text}`)
   }
   return res.json() as Promise<T>
 }
@@ -385,33 +419,39 @@ export async function sendChat(
 // ── Memory ───────────────────────────────────────────────────────
 
 export async function getMemory(): Promise<unknown> {
-  return hermesGet('/api/memory')
+  return splitCapabilityRequest('memory', '/api/memory')
 }
 
 // ── Skills ───────────────────────────────────────────────────────
 
 export async function listSkills(): Promise<unknown> {
-  return hermesGet('/api/skills')
+  return splitCapabilityRequest('skills', '/api/skills')
 }
 
 export async function getSkill(name: string): Promise<unknown> {
-  return hermesGet(`/api/skills/${encodeURIComponent(name)}`)
+  return splitCapabilityRequest(
+    'skills',
+    `/api/skills/${encodeURIComponent(name)}`,
+  )
 }
 
 export async function getSkillCategories(): Promise<unknown> {
-  return hermesGet('/api/skills/categories')
+  return splitCapabilityRequest('skills', '/api/skills/categories')
 }
 
 // ── Config ───────────────────────────────────────────────────────
 
 export async function getConfig(): Promise<HermesConfig> {
-  return hermesGet<HermesConfig>('/api/config')
+  return splitCapabilityRequest<HermesConfig>('config', '/api/config')
 }
 
 export async function patchConfig(
   patch: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  return hermesPatch<Record<string, unknown>>('/api/config', patch)
+  return splitCapabilityRequest<Record<string, unknown>>('config', '/api/config', {
+    method: 'PATCH',
+    body: patch,
+  })
 }
 
 // ── Models ───────────────────────────────────────────────────────

--- a/src/server/memory-browser.ts
+++ b/src/server/memory-browser.ts
@@ -15,11 +15,20 @@ export type MemorySearchMatch = {
   text: string
 }
 
+/** The only subdirectories the memory browser will surface. */
+const MEMORY_DIRS = ['memory', 'memories'] as const
+
+/**
+ * Depth cap for the memory walk. Memory trees are shallow; the cap exists
+ * because a symlinked directory pointing at an ancestor would otherwise
+ * recurse forever (statSync follows symlinks).
+ */
+const MAX_MEMORY_DEPTH = 8
+
 function isBrowserMemoryPath(relativePath: string): boolean {
   return (
     relativePath === 'MEMORY.md' ||
-    relativePath.startsWith('memory/') ||
-    relativePath.startsWith('memories/')
+    MEMORY_DIRS.some((dir) => relativePath.startsWith(`${dir}/`))
   )
 }
 
@@ -91,7 +100,10 @@ function walkWorkspaceDir(
   entries: Array<MemoryFileMeta>,
   workspaceRoot: string,
   dirPath: string,
+  depth = 0,
 ) {
+  if (depth > MAX_MEMORY_DEPTH) return
+
   let dirEntries: Array<string>
   try {
     dirEntries = fs.readdirSync(dirPath)
@@ -109,7 +121,7 @@ function walkWorkspaceDir(
     }
     if (stats.isDirectory()) {
       if (shouldSkipDirectory(name)) continue
-      walkWorkspaceDir(entries, workspaceRoot, fullPath)
+      walkWorkspaceDir(entries, workspaceRoot, fullPath, depth + 1)
       continue
     }
     pushIfMarkdownFile(entries, workspaceRoot, fullPath)
@@ -129,11 +141,30 @@ function compareMemoryFiles(a: MemoryFileMeta, b: MemoryFileMeta): number {
   return a.path.localeCompare(b.path)
 }
 
+/**
+ * Only `MEMORY.md`, `memory/**` and `memories/**` can pass
+ * isBrowserMemoryPath(), so only those are worth walking.
+ *
+ * This used to walk the entire Hermes home and filter afterwards. On a real
+ * install that home holds skills, LSP binaries and model caches — ~400k files
+ * on the machine this was measured on — each one stat()ed to find markdown in
+ * at most three places, with symlinked skill directories followed along the
+ * way. The Memory panel did not fail, it simply never responded, and because
+ * this runs synchronously it took every request behind it down with it.
+ * Measured 90s+ -> 34ms.
+ */
 export function listMemoryFiles(): Array<MemoryFileMeta> {
   const workspaceRoot = getMemoryWorkspaceRoot()
   const results: Array<MemoryFileMeta> = []
 
-  walkWorkspaceDir(results, workspaceRoot, workspaceRoot)
+  pushIfMarkdownFile(
+    results,
+    workspaceRoot,
+    path.join(workspaceRoot, 'MEMORY.md'),
+  )
+  for (const dir of MEMORY_DIRS) {
+    walkWorkspaceDir(results, workspaceRoot, path.join(workspaceRoot, dir))
+  }
 
   results.sort(compareMemoryFiles)
   return results

--- a/src/server/openai-compat-api.ts
+++ b/src/server/openai-compat-api.ts
@@ -1,7 +1,8 @@
-import { HERMES_API } from './gateway-capabilities'
-
-/** Optional bearer token for authenticated OpenAI-compatible endpoints (e.g. Codex OAuth). */
-const BEARER_TOKEN = process.env.HERMES_API_TOKEN || ''
+import {
+  HERMES_API,
+  ensureGatewayProbed,
+  getAuthHeaders,
+} from './gateway-capabilities'
 
 /** Cached first available model from /v1/models — used as fallback when no model is specified. */
 let _cachedDefaultModel: string | null = null
@@ -13,10 +14,11 @@ async function getDefaultModel(): Promise<string> {
     return _cachedDefaultModel
   }
   try {
-    const headers: Record<string, string> = {}
-    if (BEARER_TOKEN) headers['Authorization'] = `Bearer ${BEARER_TOKEN}`
+    // Use the discovered gateway key (env var or ~/.hermes .env files), not a
+    // bare HERMES_API_TOKEN read — see issue #17.
+    await ensureGatewayProbed()
     const res = await fetch(`${HERMES_API}/v1/models`, {
-      headers,
+      headers: getAuthHeaders(),
       signal: AbortSignal.timeout(3_000),
     })
     if (res.ok) {
@@ -157,9 +159,10 @@ export async function openaiChat(
   messages: Array<OpenAICompatMessage>,
   options: OpenAIChatOptions = {},
 ): Promise<string | AsyncGenerator<StreamChunkType, void, void>> {
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-  if (BEARER_TOKEN) {
-    headers['Authorization'] = `Bearer ${BEARER_TOKEN}`
+  await ensureGatewayProbed()
+  const headers: Record<string, string> = {
+    ...getAuthHeaders(),
+    'Content-Type': 'application/json',
   }
   if (options.sessionId) {
     headers['X-Hermes-Session-Id'] = options.sessionId

--- a/src/test/dashboard-probe.test.ts
+++ b/src/test/dashboard-probe.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Regression guard for issue #23's dashboard probe.
+ *
+ * The Hermes Agent dashboard serves a single-page app, and its catch-all
+ * answers ANY unknown path with `200 text/html` — verified against a live
+ * v0.19 dashboard, where `/definitely-not-a-real-path` returns 200 HTML while
+ * the real `/api/*` routes return JSON.
+ *
+ * The probe used to treat "not 401/404/403" as proof the capability existed,
+ * so a dashboard whose routes had moved — or a mistyped HERMES_DASHBOARD_URL
+ * pointing at any SPA — reported every capability as available and then fed
+ * HTML to JSON.parse on the first real data call.
+ */
+
+const DASHBOARD = 'http://dashboard.test'
+const GATEWAY = 'http://gateway.test'
+
+function response(body: string, status: number, contentType: string): Response {
+  return new Response(body, {
+    status,
+    headers: { 'Content-Type': contentType },
+  })
+}
+
+/**
+ * Route by host: the gateway 404s the split capabilities (v0.19+ moved them
+ * off it) so the dashboard branch is what decides the outcome.
+ */
+function stubFetch(dashboardReply: () => Response) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: string | URL | Request) => {
+      const url = String(input instanceof Request ? input.url : input)
+      if (url.startsWith(DASHBOARD)) return Promise.resolve(dashboardReply())
+      if (url.includes('/health'))
+        return Promise.resolve(response('{}', 200, 'application/json'))
+      return Promise.resolve(
+        response('{"detail":"Not Found"}', 404, 'application/json'),
+      )
+    }),
+  )
+}
+
+async function probeWith(dashboardReply: () => Response) {
+  vi.resetModules()
+  vi.stubEnv('HERMES_DASHBOARD_URL', DASHBOARD)
+  vi.stubEnv('HERMES_DASHBOARD_SESSION_TOKEN', 'test-token')
+  vi.stubEnv('HERMES_API_URL', GATEWAY)
+  stubFetch(dashboardReply)
+
+  const mod = await import('../server/gateway-capabilities')
+  const capabilities = await mod.ensureGatewayProbed()
+  return { capabilities, sources: mod.getCapabilitySources(), mod }
+}
+
+describe('dashboard capability probe (issue #23)', () => {
+  beforeEach(() => {
+    vi.stubEnv('HERMES_API_TOKEN', '')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  it('does NOT accept a 200 text/html SPA catch-all as a capability', async () => {
+    const { capabilities, sources } = await probeWith(() =>
+      response('<!doctype html><html><body>SPA</body></html>', 200, 'text/html'),
+    )
+
+    expect(capabilities.skills).toBe(false)
+    expect(capabilities.memory).toBe(false)
+    expect(capabilities.config).toBe(false)
+    // and it must not have pointed data calls at the dashboard
+    expect(sources.skills).toBeNull()
+    expect(sources.memory).toBeNull()
+    expect(sources.config).toBeNull()
+  })
+
+  it('accepts a real JSON response and routes data calls to the dashboard', async () => {
+    const { capabilities, sources } = await probeWith(() =>
+      response('{"skills":[]}', 200, 'application/json'),
+    )
+
+    expect(capabilities.skills).toBe(true)
+    expect(sources.skills).toBe('dashboard')
+  })
+
+  it('reports the gateway tier as unauthorized when it rejects our key', async () => {
+    // /api/connection-status used to recompute the tier itself with a union
+    // that had no 'unauthorized' member, so a gateway rejecting our API key
+    // surfaced as "Connected". It now delegates here; this pins the behaviour
+    // it delegates to.
+    vi.resetModules()
+    vi.stubEnv('HERMES_API_URL', GATEWAY)
+    vi.stubEnv('HERMES_DASHBOARD_URL', '')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          response('{"detail":"Unauthorized"}', 401, 'application/json'),
+        ),
+      ),
+    )
+
+    const mod = await import('../server/gateway-capabilities')
+    await mod.ensureGatewayProbed()
+
+    expect(mod.isGatewayUnauthorized()).toBe(true)
+    expect(mod.getConnectionStatus()).toBe('unauthorized')
+  })
+
+  it('treats a dashboard 401 as unauthorized without blaming the gateway', async () => {
+    const { capabilities, mod } = await probeWith(() =>
+      response('{"detail":"Unauthorized"}', 401, 'application/json'),
+    )
+
+    expect(mod.isDashboardUnauthorized()).toBe(true)
+    // A bad dashboard token must never mark the gateway unauthorized — that
+    // flag drives the whole app's connection status.
+    expect(mod.isGatewayUnauthorized()).toBe(false)
+    // The capability itself is absent: the gateway 404s it on v0.19+.
+    expect(capabilities.skills).toBe(false)
+  })
+})

--- a/src/test/gateway-auth-coverage.test.ts
+++ b/src/test/gateway-auth-coverage.test.ts
@@ -1,0 +1,93 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Regression guard for issue #17: every server-side fetch to the Hermes
+ * gateway must carry the discovered bearer token, and nothing may re-read the
+ * raw env vars that the canonical discovery in gateway-key.ts /
+ * gateway-capabilities.ts owns (shadow copies are how the unauthenticated
+ * call sites crept in).
+ */
+
+const SRC_ROOT = path.resolve(__dirname, '..')
+
+function walk(dir: string): Array<string> {
+  const out: Array<string> = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...walk(full))
+    } else if (/\.(ts|tsx)$/.test(entry.name)) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+const files = walk(SRC_ROOT).map((full) => ({
+  rel: path.relative(SRC_ROOT, full),
+  text: fs.readFileSync(full, 'utf8'),
+}))
+
+describe('gateway auth coverage (issue #17)', () => {
+  it('HERMES_API_TOKEN is only read by the canonical key discovery', () => {
+    const offenders = files
+      .filter((f) => f.text.includes('process.env.HERMES_API_TOKEN'))
+      .map((f) => f.rel)
+      .filter(
+        (rel) => rel !== 'server/gateway-key.ts' && !rel.startsWith('test/'),
+      )
+    expect(offenders).toEqual([])
+  })
+
+  /*
+   * Deliberately NOT asserted here yet:
+   *
+   *   - `process.env.HERMES_API_URL` is still read directly by
+   *     routes/api/models.ts and routes/settings/index.tsx.
+   *   - hermes-jobs.ts, hermes-jobs.$jobId.ts and hermes-runs.ts still fetch
+   *     the gateway with no auth header.
+   *
+   * Those are exactly the call sites PR #19 fixes, by the reporter of issue
+   * #17. Asserting them here would make this branch depend on that one and
+   * would duplicate its work. Once #19 lands, add:
+   *
+   *   it('HERMES_API_URL is only read by gateway-capabilities', ...)
+   *   it('every file fetching the gateway references an auth-header helper', ...)
+   *
+   * following the same shape as the checks above and below.
+   */
+
+  it('split-capability fetches use the target headers, not bare ones', () => {
+    // The check above only recognizes `fetch(`${HERMES_API}` — it is blind to
+    // the shape this split introduces, `fetch(`${target.base}`. Without this
+    // second check the guard would quietly stop guarding the newest call sites.
+    const offenders = files
+      .filter((f) => f.text.includes('fetch(`${target.base}'))
+      .filter((f) => !f.text.includes('headers: target.headers'))
+      .filter((f) => !f.text.includes('...target.headers'))
+      .map((f) => f.rel)
+    expect(offenders).toEqual([])
+  })
+
+  it('getCapabilityTarget callers always supply a credentialed fallback', () => {
+    // `getCapabilityTarget()` returns null when neither server exposes the
+    // capability. Falling back to a bare `{ base: HERMES_API }` without
+    // headers is how an unauthenticated call site reappears.
+    const offenders = files
+      .filter(
+        (f) =>
+          f.rel !== 'server/gateway-capabilities.ts' &&
+          !f.rel.startsWith('test/') &&
+          f.text.includes('getCapabilityTarget('),
+      )
+      .filter(
+        (f) =>
+          !f.text.includes('getAuthHeaders()') &&
+          !f.text.includes('hermesAuthHeaders()'),
+      )
+      .map((f) => f.rel)
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
## What

Makes Skills, Memory and Config work against Hermes Agent v0.19+, where those routes no longer live on the gateway. Closes #23, and closes four unauthenticated gateway call sites from #17 that PR #19 does not cover.

**This complements #19 and #20 rather than competing with them.** I checked both diffs: #19 fixes the eight route files issue #17 names, #20 fixes `hermes-api.ts`/`context-usage.ts` list parsing. Neither file set overlaps with the call sites here, and this branch deliberately leaves `listSessions`/`getMessages` and those eight routes untouched so both PRs still apply cleanly.

### 1. The actual cause of #23

The reporter's diagnosis is correct. Agent v0.19 moved `/api/skills`, `/api/memory` and `/api/config` off the gateway's embedded `api_server` (8642) onto the agent's own dashboard backend (`hermes_cli/web_server.py`, separate process, default 9119, its own session auth). Studio probes all three against the single `HERMES_API_URL`, gets 404, and marks them missing — so on every current agent the panels report "unavailable" and the startup log tells the user to upgrade an agent that is already newer than the advice.

**Optional second backend.** `HERMES_DASHBOARD_URL` + `HERMES_DASHBOARD_SESSION_TOKEN` (`HERMES_DASHBOARD_TOKEN` also accepted), sent as `X-Hermes-Session-Token`. The three capabilities are probed on the dashboard first and fall back to the gateway for pre-v0.19 agents; `getCapabilityTarget()` then routes each data call to whichever server answered, with that server's credentials.

Both variables are server-side only and never inlined into the client bundle. **Neither is required** — with them unset nothing contacts the dashboard and every panel keeps working from local `~/.hermes`. `skills`/`memory`/`config` also no longer gate the "enhanced" tier or the upgrade warning, because their absence from the gateway is now the normal state rather than a version-lag signal.

### 2. A dashboard probe cannot go by status code

Worth flagging for review, because it is not obvious: the dashboard serves an SPA whose catch-all answers **any** unknown path with `200 text/html`. Measured against a live v0.19 dashboard — `/definitely-not-a-real-path` returns 200 HTML while the real `/api/*` routes return JSON.

A status-only check therefore reports every capability as present on a dashboard whose routes have moved or whose URL is mistyped, and then feeds HTML to `JSON.parse` at data-fetch time. Requiring a JSON content type fails safe in the right direction: a real endpoint answering in some other content type is merely missed, and all three degrade to their local fallbacks. `src/test/dashboard-probe.test.ts` pins this.

Dashboard 401s set a separate `dashboardUnauthorized` flag — a bad dashboard token must never mark the *gateway* unauthorized.

> The dashboard token is ephemeral by default: the dashboard generates a random one per process unless started with `HERMES_DASHBOARD_SESSION_TOKEN` set. Documented in `docs/HERMES_AGENT_COMPATIBILITY.md`, since a hardcoded value otherwise goes stale on the next agent restart.

### 3. Panels that never needed the gateway at all

Three of the reported symptoms turned out not to be about the route split:

- **Settings/Providers was gated on the `config` capability while being 100% filesystem-backed.** A probe of an endpoint the panel does not use was blanking it. Gate removed. It also fetched `/api/config-get` and `/api/config-patch` — **routes that have never existed in this repo**, so they 404'd unconditionally for anyone who got past the gate, on every agent version. Added, local-filesystem, behind the session check.
- **`/api/mcp/servers`** read the gateway's `/api/config` behind the same gate while `PUT` wrote the local `config.yaml`. Reads and writes now agree.
- **`/api/memory` 503'd.** It now degrades to the same local listing the Memory screen uses — but that listing had to be fixed first: it walked the *entire* Hermes home to find markdown in at most three places, following symlinked skill directories, synchronously. On the machine this was measured on that is ~400k files, and because it is synchronous it took every queued request down with it. Now walks only `MEMORY.md`, `memory/` and `memories/`, depth-capped. **90s+ → 34ms.** The Memory panel was not unavailable; it was hanging.

### 4. Four unauthenticated call sites #19 does not cover

| Pri | Site | Defect |
|---|---|---|
| P0 | `server/openai-compat-api.ts` | kept a private `BEARER_TOKEN = process.env.HERMES_API_TOKEN` shadow that bypassed key discovery entirely — **portable-mode chat 401'd** whenever the key lived only in `~/.hermes/.env` |
| P1 | `screens/settings/providers-screen.tsx` | a **client** component fetching the gateway's `/v1/models` directly, cross-origin with no credentials, and importing `getConfig`/`patchConfig` from the server client. `vite.config.ts` inlines `HERMES_API_URL` into the client bundle, which is what made it look like it should work |
| P1 | `routes/api/skills.ts` | local `HERMES_API_URL` const, bypassing both the discovered key and the 8643 auto-detect |
| P2 | `routes/api/skills/install.ts` | POSTed unauthenticated and fell **silently** through to the clawhub CLI, so a native install looked like "clawhub not installed" |

Plus one #18-class straggler: `routes/api/skills/hub-search.ts` read only `.skills` from `/api/skills`, never `.data`/`.items` — so against a gateway answering in the OpenAI list shape the skills marketplace showed **every skill as not-installed**.

### 5. Guard

`src/test/gateway-auth-coverage.test.ts` asserts what this branch owns: no shadow reads of `HERMES_API_TOKEN`, split-capability fetches use the target's headers, and every `getCapabilityTarget()` caller supplies a credentialed fallback.

Two broader assertions are **left commented out with instructions**, because they currently fail on `main` for call sites that belong to #19 — asserting them here would duplicate that PR's work and make this branch depend on it. They should be enabled once #19 lands; the comment says exactly that.

## Verification

- `vitest`: **190 → 197 passing**, 18 files, none broken.
- `eslint`: **622 errors / 88 warnings — identical to `main`.** No new errors or warnings.
- `tsc --noEmit`: **no new errors vs `main`.** (`main` currently has 4: two are #14's missing katex deps, one is #18's `sessions.ts` `.data` access, one is a pre-existing `version-compatibility.ts` overload.)
- `routeTree.gen.ts` regenerated for the two new config routes.

Note for maintainers: `vite build` currently fails on `main` — `Rollup failed to resolve import "rehype-katex"` — which is #14. #21 fixes that; it is unrelated to this branch.

## Reviewing this

The riskiest change is `gateway-capabilities.ts`. The behaviour with `HERMES_DASHBOARD_URL` unset is intended to be byte-for-byte the old behaviour except that skills/memory/config no longer gate the enhanced tier — worth confirming that reading, since that is the compatibility promise for everyone not running v0.19+.

Happy to split this into smaller PRs if that is easier to review, and happy to rebase after #19/#20 land.

Closes #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
