### PR TITLE
fix(auth): give multi-user mode a real identity, and close the task-event leaks (closes #8)

### DIFF
--- a/docs/MULTI_USER_ROADMAP.md
+++ b/docs/MULTI_USER_ROADMAP.md
@@ -1,8 +1,45 @@
 # Multi-User Access Control Roadmap
 
-**Status:** Foundation implemented (Phase 1), full RBAC pending (Phase 2)  
+**Status:** Phase 1 + Phase 2 core implemented (2026-08-13) — see "Phase 2 delivered" below; remaining: management UI, session/chat isolation  
 **Issue:** #8 — Kanban board shows all tasks to all users  
-**Date:** 2026-07-03
+**Date:** 2026-07-03 (updated 2026-08-13)
+
+## Phase 2 delivered (2026-08-13)
+
+- **Per-user identity (2a):** `HERMES_USERS='alice:pw1,bob:pw2'` enables
+  multi-user logins (username + password, `src/server/user-credentials.ts`);
+  `/api/auth` associates the session token with the userId;
+  `HERMES_SUPER_ADMINS='alice'` grants super_admin at login. Multi-user mode
+  counts as password protection even without `HERMES_PASSWORD`, and the
+  legacy shared password is rejected in this mode. Login form gains a
+  username field (driven by `multiUser` from `/api/auth-check`).
+- **Fail-closed defaults:** in multi-user mode, requests with no resolvable
+  identity are denied on `/api/tasks` (list + create) and by
+  `canAccessTask()` — a misconfiguration can no longer silently reopen the
+  all-tasks leak.
+- **Event-surface leak closure (2b):** task events now carry
+  `createdBy`/`profileId` and are filtered per user by `canSeeTaskEvent()` on
+  all four event surfaces — `/api/events`, `/api/chat-events`,
+  `/api/events/replay`, and `/api/audit`. Legacy stored events without
+  ownership are visible only to super admins.
+
+  > `/api/events` was the last one closed. An earlier revision of this document
+  > claimed its auth was "fixed in a separate branch"; that was wrong — no such
+  > branch existed, and the route had been unauthenticated and unfiltered since
+  > the initial release, streaming every user's task activity to any caller. It
+  > is fixed here, and covered by route-level tests so a green suite can no
+  > longer hide it.
+- **Admin surface (2c):** `GET/PATCH /api/admin/users` (super_admin only) —
+  list users from `HERMES_USERS`, set roles, manage profile bindings.
+- **Profile-bound tasks (2d):** tasks accept an optional `profileId`
+  (validated against the creator's bindings); regular admins see tasks they
+  created OR tasks of profiles bound to their account.
+  `getAccessibleProfiles()` now returns `null` for "all" (was a misleading
+  `[]`).
+
+Remaining: user management UI in settings (roles/bindings are API-only),
+extending isolation to sessions/chat (item 4 below), and a migration story
+for orphan tasks (`createdBy: 'user' | 'unknown'` — super admins see them).
 
 ## What's Implemented (Phase 1)
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -106,6 +106,8 @@ import { Route as ApiHermesJobsJobIdRouteImport } from './routes/api/hermes-jobs
 import { Route as ApiEventsReplayRouteImport } from './routes/api/events/replay'
 import { Route as ApiCrewsCrewIdRouteImport } from './routes/api/crews/$crewId'
 import { Route as ApiAgentsAgentIdRouteImport } from './routes/api/agents/$agentId'
+import { Route as ApiAdminUsersRouteImport } from './routes/api/admin/users'
+import { Route as ApiAdminOrphanTasksRouteImport } from './routes/api/admin/orphan-tasks'
 import { Route as ApiCrewsTemplatesIndexRouteImport } from './routes/api/crews/templates/index'
 import { Route as ApiTasksTaskIdMoveRouteImport } from './routes/api/tasks/$taskId.move'
 import { Route as ApiSessionsSessionKeyStatusRouteImport } from './routes/api/sessions/$sessionKey.status'
@@ -604,6 +606,16 @@ const ApiAgentsAgentIdRoute = ApiAgentsAgentIdRouteImport.update({
   path: '/api/agents/$agentId',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiAdminUsersRoute = ApiAdminUsersRouteImport.update({
+  id: '/api/admin/users',
+  path: '/api/admin/users',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAdminOrphanTasksRoute = ApiAdminOrphanTasksRouteImport.update({
+  id: '/api/admin/orphan-tasks',
+  path: '/api/admin/orphan-tasks',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiCrewsTemplatesIndexRoute = ApiCrewsTemplatesIndexRouteImport.update({
   id: '/api/crews/templates/',
   path: '/api/crews/templates/',
@@ -734,6 +746,8 @@ export interface FileRoutesByFullPath {
   '/chat/': typeof ChatIndexRoute
   '/crews/': typeof CrewsIndexRoute
   '/settings/': typeof SettingsIndexRoute
+  '/api/admin/orphan-tasks': typeof ApiAdminOrphanTasksRoute
+  '/api/admin/users': typeof ApiAdminUsersRoute
   '/api/agents/$agentId': typeof ApiAgentsAgentIdRoute
   '/api/crews/$crewId': typeof ApiCrewsCrewIdRouteWithChildren
   '/api/events/replay': typeof ApiEventsReplayRoute
@@ -844,6 +858,8 @@ export interface FileRoutesByTo {
   '/chat': typeof ChatIndexRoute
   '/crews': typeof CrewsIndexRoute
   '/settings': typeof SettingsIndexRoute
+  '/api/admin/orphan-tasks': typeof ApiAdminOrphanTasksRoute
+  '/api/admin/users': typeof ApiAdminUsersRoute
   '/api/agents/$agentId': typeof ApiAgentsAgentIdRoute
   '/api/crews/$crewId': typeof ApiCrewsCrewIdRouteWithChildren
   '/api/events/replay': typeof ApiEventsReplayRoute
@@ -956,6 +972,8 @@ export interface FileRoutesById {
   '/chat/': typeof ChatIndexRoute
   '/crews/': typeof CrewsIndexRoute
   '/settings/': typeof SettingsIndexRoute
+  '/api/admin/orphan-tasks': typeof ApiAdminOrphanTasksRoute
+  '/api/admin/users': typeof ApiAdminUsersRoute
   '/api/agents/$agentId': typeof ApiAgentsAgentIdRoute
   '/api/crews/$crewId': typeof ApiCrewsCrewIdRouteWithChildren
   '/api/events/replay': typeof ApiEventsReplayRoute
@@ -1069,6 +1087,8 @@ export interface FileRouteTypes {
     | '/chat/'
     | '/crews/'
     | '/settings/'
+    | '/api/admin/orphan-tasks'
+    | '/api/admin/users'
     | '/api/agents/$agentId'
     | '/api/crews/$crewId'
     | '/api/events/replay'
@@ -1179,6 +1199,8 @@ export interface FileRouteTypes {
     | '/chat'
     | '/crews'
     | '/settings'
+    | '/api/admin/orphan-tasks'
+    | '/api/admin/users'
     | '/api/agents/$agentId'
     | '/api/crews/$crewId'
     | '/api/events/replay'
@@ -1290,6 +1312,8 @@ export interface FileRouteTypes {
     | '/chat/'
     | '/crews/'
     | '/settings/'
+    | '/api/admin/orphan-tasks'
+    | '/api/admin/users'
     | '/api/agents/$agentId'
     | '/api/crews/$crewId'
     | '/api/events/replay'
@@ -1399,6 +1423,8 @@ export interface RootRouteChildren {
   CrewsCrewIdRoute: typeof CrewsCrewIdRoute
   ChatIndexRoute: typeof ChatIndexRoute
   CrewsIndexRoute: typeof CrewsIndexRoute
+  ApiAdminOrphanTasksRoute: typeof ApiAdminOrphanTasksRoute
+  ApiAdminUsersRoute: typeof ApiAdminUsersRoute
   ApiAgentsAgentIdRoute: typeof ApiAgentsAgentIdRoute
   ApiCrewsCrewIdRoute: typeof ApiCrewsCrewIdRouteWithChildren
   ApiHermesProxySplatRoute: typeof ApiHermesProxySplatRoute
@@ -2109,6 +2135,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAgentsAgentIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/admin/users': {
+      id: '/api/admin/users'
+      path: '/api/admin/users'
+      fullPath: '/api/admin/users'
+      preLoaderRoute: typeof ApiAdminUsersRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/admin/orphan-tasks': {
+      id: '/api/admin/orphan-tasks'
+      path: '/api/admin/orphan-tasks'
+      fullPath: '/api/admin/orphan-tasks'
+      preLoaderRoute: typeof ApiAdminOrphanTasksRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/crews/templates/': {
       id: '/api/crews/templates/'
       path: '/api/crews/templates'
@@ -2391,6 +2431,8 @@ const rootRouteChildren: RootRouteChildren = {
   CrewsCrewIdRoute: CrewsCrewIdRoute,
   ChatIndexRoute: ChatIndexRoute,
   CrewsIndexRoute: CrewsIndexRoute,
+  ApiAdminOrphanTasksRoute: ApiAdminOrphanTasksRoute,
+  ApiAdminUsersRoute: ApiAdminUsersRoute,
   ApiAgentsAgentIdRoute: ApiAgentsAgentIdRoute,
   ApiCrewsCrewIdRoute: ApiCrewsCrewIdRouteWithChildren,
   ApiHermesProxySplatRoute: ApiHermesProxySplatRoute,

--- a/src/routes/api/admin/orphan-tasks.ts
+++ b/src/routes/api/admin/orphan-tasks.ts
@@ -1,0 +1,151 @@
+/**
+ * GET  /api/admin/orphan-tasks — list tasks nobody can see
+ * POST /api/admin/orphan-tasks — reassign them to a real user
+ *
+ * Issue #8 Phase 2d, the migration half.
+ *
+ * Tasks created before per-user identity existed carry the placeholder
+ * `createdBy` values 'user' or 'unknown' (task-store still defaults to 'user'
+ * when no creator is supplied, e.g. for conductor/crew-generated tasks). Those
+ * strings match no configured username, so once multi-user mode is switched on
+ * `canAccessTask()` hides them from every regular admin — permanently, with no
+ * way to claim them from the UI. Only a super admin can see them at all, which
+ * is safe but leaves the board looking like data was lost.
+ *
+ * This is the deliberate way out: a super admin sees exactly what is stranded
+ * and hands each batch to a real account. Super-admin only, multi-user only —
+ * in single-user mode nothing is hidden and there is nothing to migrate.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import {
+  getUserIdFromRequest,
+  isAuthenticated,
+} from '../../../server/auth-middleware'
+import { requireJsonContentType } from '../../../server/rate-limit'
+import { listTasks, updateTaskOwner } from '../../../server/task-store'
+import {
+  isMultiUserMode,
+  listConfiguredUsernames,
+} from '../../../server/user-credentials'
+import { getUserProfile } from '../../../server/user-profiles'
+
+/** createdBy values that predate per-user identity and match no real account. */
+export const ORPHAN_CREATOR_IDS = new Set(['user', 'unknown', ''])
+
+function requireSuperAdmin(request: Request): Response | { userId: string } {
+  if (!isAuthenticated(request)) {
+    return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+  }
+  if (!isMultiUserMode()) {
+    return json(
+      {
+        ok: false,
+        error:
+          'Multi-user mode is not enabled — no tasks are hidden, so there is nothing to migrate.',
+      },
+      { status: 400 },
+    )
+  }
+  const userId = getUserIdFromRequest(request)
+  if (!userId) {
+    return json(
+      { ok: false, error: 'Session has no user identity — log in again' },
+      { status: 401 },
+    )
+  }
+  if (getUserProfile(userId).role !== 'super_admin') {
+    return json({ ok: false, error: 'Requires super_admin' }, { status: 403 })
+  }
+  return { userId }
+}
+
+function isOrphan(createdBy: string | undefined | null): boolean {
+  if (!createdBy) return true
+  if (ORPHAN_CREATOR_IDS.has(createdBy)) return true
+  // A creator who is no longer in HERMES_USERS is equally unreachable.
+  return !listConfiguredUsernames().includes(createdBy)
+}
+
+export const Route = createFileRoute('/api/admin/orphan-tasks')({
+  server: {
+    handlers: {
+      GET: ({ request }) => {
+        const gate = requireSuperAdmin(request)
+        if (gate instanceof Response) return gate
+
+        const orphans = listTasks()
+          .filter((task) => isOrphan(task.createdBy))
+          .map((task) => ({
+            id: task.id,
+            title: task.title,
+            column: task.column,
+            createdBy: task.createdBy,
+            profileId: task.profileId ?? null,
+            createdAt: task.createdAt,
+          }))
+
+        return json({
+          ok: true,
+          orphans,
+          assignableUsers: listConfiguredUsernames(),
+        })
+      },
+
+      POST: async ({ request }) => {
+        const gate = requireSuperAdmin(request)
+        if (gate instanceof Response) return gate
+        const csrfCheck = requireJsonContentType(request)
+        if (csrfCheck) return csrfCheck
+
+        const body = (await request.json().catch(() => null)) as {
+          taskIds?: unknown
+          createdBy?: unknown
+        } | null
+
+        const targetUser =
+          body && typeof body.createdBy === 'string'
+            ? body.createdBy.trim()
+            : ''
+        if (!targetUser) {
+          return json(
+            { ok: false, error: 'createdBy is required' },
+            { status: 400 },
+          )
+        }
+        if (!listConfiguredUsernames().includes(targetUser)) {
+          return json(
+            {
+              ok: false,
+              error: `Unknown user: ${targetUser} (users are defined in HERMES_USERS)`,
+            },
+            { status: 404 },
+          )
+        }
+
+        if (
+          !Array.isArray(body?.taskIds) ||
+          body.taskIds.some((id) => typeof id !== 'string')
+        ) {
+          return json(
+            { ok: false, error: 'taskIds must be an array of strings' },
+            { status: 400 },
+          )
+        }
+
+        // Only ever reassign tasks that are actually stranded. Without this a
+        // super admin could quietly take ownership of another user's tasks
+        // through the migration endpoint.
+        const reassigned: Array<string> = []
+        const skipped: Array<string> = []
+        for (const taskId of body.taskIds as Array<string>) {
+          const updated = updateTaskOwner(taskId, targetUser, isOrphan)
+          if (updated) reassigned.push(taskId)
+          else skipped.push(taskId)
+        }
+
+        return json({ ok: true, reassigned, skipped, createdBy: targetUser })
+      },
+    },
+  },
+})

--- a/src/routes/api/admin/users.ts
+++ b/src/routes/api/admin/users.ts
@@ -1,0 +1,158 @@
+/**
+ * GET   /api/admin/users — list users, roles, and profile bindings
+ * PATCH /api/admin/users — update a user's role and/or profile bindings
+ *
+ * Issue #8 Phase 2: the role/binding store (user-profiles.ts) previously had
+ * no HTTP surface at all — promotions required a manual Redis write. Only
+ * super admins may use these endpoints, and only in multi-user mode
+ * (HERMES_USERS set); in single-user mode there are no users to manage.
+ *
+ * Usernames and passwords themselves live in the HERMES_USERS env var —
+ * this API manages roles and profile bindings, not credentials.
+ */
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import {
+  getUserIdFromRequest,
+  isAuthenticated,
+} from '../../../server/auth-middleware'
+import { requireJsonContentType } from '../../../server/rate-limit'
+import {
+  isMultiUserMode,
+  listConfiguredUsernames,
+  superAdminUsernames,
+} from '../../../server/user-credentials'
+import {
+  getUserProfile,
+  updateUserProfile,
+} from '../../../server/user-profiles'
+
+function requireSuperAdmin(request: Request): Response | { userId: string } {
+  if (!isAuthenticated(request)) {
+    return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+  }
+  if (!isMultiUserMode()) {
+    return json(
+      {
+        ok: false,
+        error:
+          'Multi-user mode is not enabled. Set HERMES_USERS (and optionally HERMES_SUPER_ADMINS) to manage users.',
+      },
+      { status: 400 },
+    )
+  }
+  const userId = getUserIdFromRequest(request)
+  if (!userId) {
+    return json(
+      { ok: false, error: 'Session has no user identity — log in again' },
+      { status: 401 },
+    )
+  }
+  if (getUserProfile(userId).role !== 'super_admin') {
+    return json({ ok: false, error: 'Requires super_admin' }, { status: 403 })
+  }
+  return { userId }
+}
+
+export const Route = createFileRoute('/api/admin/users')({
+  server: {
+    handlers: {
+      GET: ({ request }) => {
+        const gate = requireSuperAdmin(request)
+        if (gate instanceof Response) return gate
+
+        const envSupers = superAdminUsernames()
+        const users = listConfiguredUsernames().map((username) => {
+          const profile = getUserProfile(username)
+          return {
+            userId: username,
+            role: profile.role,
+            profileIds: profile.profileIds,
+            // super_admin re-granted at every login via HERMES_SUPER_ADMINS —
+            // demoting such a user here won't stick past their next login.
+            envSuperAdmin: envSupers.has(username),
+          }
+        })
+        return json({ ok: true, users })
+      },
+
+      PATCH: async ({ request }) => {
+        const gate = requireSuperAdmin(request)
+        if (gate instanceof Response) return gate
+        const csrfCheck = requireJsonContentType(request)
+        if (csrfCheck) return csrfCheck
+
+        const body = (await request.json().catch(() => null)) as {
+          userId?: unknown
+          role?: unknown
+          profileIds?: unknown
+        } | null
+        const targetId =
+          body && typeof body.userId === 'string' ? body.userId.trim() : ''
+        if (!targetId) {
+          return json(
+            { ok: false, error: 'userId is required' },
+            { status: 400 },
+          )
+        }
+        if (!listConfiguredUsernames().includes(targetId)) {
+          return json(
+            {
+              ok: false,
+              error: `Unknown user: ${targetId} (users are defined in HERMES_USERS)`,
+            },
+            { status: 404 },
+          )
+        }
+
+        const updates: {
+          role?: 'super_admin' | 'regular_admin'
+          profileIds?: Array<string>
+        } = {}
+        if (body?.role !== undefined) {
+          if (body.role !== 'super_admin' && body.role !== 'regular_admin') {
+            return json(
+              { ok: false, error: 'role must be super_admin or regular_admin' },
+              { status: 400 },
+            )
+          }
+          updates.role = body.role
+        }
+        if (body?.profileIds !== undefined) {
+          if (
+            !Array.isArray(body.profileIds) ||
+            body.profileIds.some((id) => typeof id !== 'string')
+          ) {
+            return json(
+              { ok: false, error: 'profileIds must be an array of strings' },
+              { status: 400 },
+            )
+          }
+          updates.profileIds = (body.profileIds as Array<string>).map((id) =>
+            id.trim(),
+          )
+        }
+        if (updates.role === undefined && updates.profileIds === undefined) {
+          return json(
+            {
+              ok: false,
+              error: 'Nothing to update — pass role and/or profileIds',
+            },
+            { status: 400 },
+          )
+        }
+
+        const profile = updateUserProfile(targetId, updates)
+        return json({
+          ok: true,
+          user: {
+            userId: profile.userId,
+            role: profile.role,
+            profileIds: profile.profileIds,
+            envSuperAdmin: superAdminUsernames().has(profile.userId),
+          },
+        })
+      },
+    },
+  },
+})

--- a/src/routes/api/audit/index.ts
+++ b/src/routes/api/audit/index.ts
@@ -11,8 +11,12 @@
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  getUserIdFromRequest,
+  isAuthenticated,
+} from '../../../server/auth-middleware'
 import { queryAuditEvents } from '../../../server/event-store'
+import { canSeeTaskEvent } from '../../../server/user-profiles'
 
 const DEFAULT_TYPES = ['tool', 'user_message', 'approval']
 const MAX_LIMIT = 500
@@ -26,11 +30,15 @@ export const Route = createFileRoute('/api/audit/')({
         }
 
         const url = new URL(request.url)
-        const sessionKey = url.searchParams.get('sessionKey')?.trim() || undefined
+        const sessionKey =
+          url.searchParams.get('sessionKey')?.trim() || undefined
 
         const typesParam = url.searchParams.get('types')
         const eventTypes = typesParam
-          ? typesParam.split(',').map((t) => t.trim()).filter(Boolean)
+          ? typesParam
+              .split(',')
+              .map((t) => t.trim())
+              .filter(Boolean)
           : DEFAULT_TYPES
 
         const sinceParam = url.searchParams.get('since')
@@ -38,21 +46,42 @@ export const Route = createFileRoute('/api/audit/')({
         const limitParam = url.searchParams.get('limit') ?? '100'
         const offsetParam = url.searchParams.get('offset') ?? '0'
 
-        const since = sinceParam && /^\d+$/.test(sinceParam) ? parseInt(sinceParam, 10) : undefined
-        const until = untilParam && /^\d+$/.test(untilParam) ? parseInt(untilParam, 10) : undefined
+        const since =
+          sinceParam && /^\d+$/.test(sinceParam)
+            ? parseInt(sinceParam, 10)
+            : undefined
+        const until =
+          untilParam && /^\d+$/.test(untilParam)
+            ? parseInt(untilParam, 10)
+            : undefined
         const limit = Math.min(
           /^\d+$/.test(limitParam) ? parseInt(limitParam, 10) : 100,
           MAX_LIMIT,
         )
         const offset = /^\d+$/.test(offsetParam) ? parseInt(offsetParam, 10) : 0
 
-        const result = queryAuditEvents({ sessionKey, eventTypes, since, until, limit, offset })
+        const result = queryAuditEvents({
+          sessionKey,
+          eventTypes,
+          since,
+          until,
+          limit,
+          offset,
+        })
+
+        // Per-user task-event filtering (Issue #8 Phase 2) — task.* types are
+        // queryable by any authenticated user, so drop foreign task events
+        // for non-super admins. total still reflects the unfiltered count.
+        const userId = getUserIdFromRequest(request)
+        const visibleEvents = result.events.filter((ev) =>
+          canSeeTaskEvent(userId, ev.eventType, ev.payload),
+        )
 
         return json({
           ok: true,
           total: result.total,
           sessions: result.sessions,
-          events: result.events.map((ev) => ({
+          events: visibleEvents.map((ev) => ({
             seq: ev.seq,
             sessionKey: ev.sessionKey,
             runId: ev.runId,

--- a/src/routes/api/auth.ts
+++ b/src/routes/api/auth.ts
@@ -9,6 +9,12 @@ import {
   verifyPassword,
 } from '../../server/auth-middleware'
 import {
+  isMultiUserMode,
+  superAdminUsernames,
+  verifyUserPassword,
+} from '../../server/user-credentials'
+import { getUserProfile, updateUserProfile } from '../../server/user-profiles'
+import {
   getClientIp,
   rateLimit,
   rateLimitResponse,
@@ -17,6 +23,7 @@ import {
 
 const AuthSchema = z.object({
   password: z.string().max(1000),
+  username: z.string().max(200).optional(),
 })
 
 export const Route = createFileRoute('/api/auth')({
@@ -26,8 +33,8 @@ export const Route = createFileRoute('/api/auth')({
         const csrfCheck = requireJsonContentType(request)
         if (csrfCheck) return csrfCheck
 
-        // If password protection is disabled, reject auth attempts
-        if (!isPasswordProtectionEnabled()) {
+        // If no auth is configured at all, reject auth attempts
+        if (!isPasswordProtectionEnabled() && !isMultiUserMode()) {
           return json(
             { ok: false, error: 'Authentication not required' },
             { status: 400 },
@@ -51,23 +58,51 @@ export const Route = createFileRoute('/api/auth')({
             )
           }
 
-          const { password } = parsed.data
+          const { password, username } = parsed.data
 
-          // Verify password
-          const valid = verifyPassword(password)
+          // Multi-user mode (HERMES_USERS set): logins are per-user so the
+          // session carries an identity for task filtering (Issue #8). The
+          // legacy shared HERMES_PASSWORD is rejected in this mode — a
+          // shared login has no userId and would bypass isolation.
+          let userId: string | undefined
+          let valid = false
+          if (isMultiUserMode()) {
+            const name = (username ?? '').trim()
+            valid = name.length > 0 && verifyUserPassword(name, password)
+            if (valid) userId = name
+          } else {
+            valid = verifyPassword(password)
+          }
 
           if (!valid) {
             // Add small delay to prevent brute force
             await new Promise((resolve) => setTimeout(resolve, 1000))
             return json(
-              { ok: false, error: 'Invalid password' },
+              {
+                ok: false,
+                error:
+                  isMultiUserMode() && !(username ?? '').trim()
+                    ? 'Username required'
+                    : 'Invalid credentials',
+              },
               { status: 401 },
             )
           }
 
-          // Generate session token
+          // Bootstrap roles: HERMES_SUPER_ADMINS grants super_admin at
+          // login (idempotent); everyone else keeps their stored role.
+          if (userId) {
+            const shouldBeSuper = superAdminUsernames().has(userId)
+            const profile = getUserProfile(userId)
+            if (shouldBeSuper && profile.role !== 'super_admin') {
+              updateUserProfile(userId, { role: 'super_admin' })
+            }
+          }
+
+          // Generate session token — associated with the user in
+          // multi-user mode so getUserIdFromRequest() resolves an identity.
           const token = generateSessionToken()
-          storeSessionToken(token)
+          storeSessionToken(token, userId)
 
           // Return success with Set-Cookie header
           return json(

--- a/src/routes/api/chat-events.ts
+++ b/src/routes/api/chat-events.ts
@@ -1,10 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { isAuthenticated } from '../../server/auth-middleware'
+import {
+  getUserIdFromRequest,
+  isAuthenticated,
+} from '../../server/auth-middleware'
 import {
   ensureBusStarted,
   subscribeToChatEvents,
 } from '../../server/chat-event-bus'
 import { getEventsSince } from '../../server/event-store'
+import { canSeeTaskEvent } from '../../server/user-profiles'
 
 /**
  * SSE endpoint for chat events.
@@ -34,6 +38,11 @@ export const Route = createFileRoute('/api/chat-events')({
         const sessionKeyParam =
           url.searchParams.get('sessionKey')?.trim() || undefined
 
+        // Task events are published under the shared 'all' session key —
+        // filter them per user so regular admins only see activity on their
+        // own/bound-profile tasks (Issue #8 Phase 2).
+        const userId = getUserIdFromRequest(request)
+
         // Standard SSE reconnect: browser sends Last-Event-ID header
         const lastEventIdHeader = request.headers.get('last-event-id')
         const lastSeq =
@@ -52,11 +61,7 @@ export const Route = createFileRoute('/api/chat-events')({
              * Emit an SSE event, optionally with an id: field for replay.
              * seq === undefined → id: line is omitted (heartbeats, connected).
              */
-            const sendEvent = (
-              event: string,
-              data: unknown,
-              seq?: number,
-            ) => {
+            const sendEvent = (event: string, data: unknown, seq?: number) => {
               if (streamClosed) return
               try {
                 let payload = ''
@@ -94,7 +99,9 @@ export const Route = createFileRoute('/api/chat-events')({
               // sessionKey to query, replay stored events before going live.
               let replayedCount = 0
               if (lastSeq > 0 && sessionKeyParam) {
-                const missed = getEventsSince(sessionKeyParam, lastSeq)
+                const missed = getEventsSince(sessionKeyParam, lastSeq).filter(
+                  (ev) => canSeeTaskEvent(userId, ev.eventType, ev.payload),
+                )
                 replayedCount = missed.length
                 for (const ev of missed) {
                   sendEvent(ev.eventType, ev.payload, ev.seq)
@@ -111,6 +118,7 @@ export const Route = createFileRoute('/api/chat-events')({
               // ── Subscribe to live events ──────────────────────────────────
               unsubscribe = subscribeToChatEvents((evt) => {
                 if (streamClosed) return
+                if (!canSeeTaskEvent(userId, evt.event, evt.data)) return
                 // Pass the seq from the event store so the browser can track
                 // its Last-Event-ID for future reconnects.
                 sendEvent(evt.event, evt.data, evt.seq)

--- a/src/routes/api/events.ts
+++ b/src/routes/api/events.ts
@@ -1,13 +1,36 @@
 import { createFileRoute } from '@tanstack/react-router'
 import {
+  getUserIdFromRequest,
+  isAuthenticated,
+} from '../../server/auth-middleware'
+import {
   ensureBusStarted,
   subscribeToChatEvents,
 } from '../../server/chat-event-bus'
+import { canSeeTaskEvent } from '../../server/user-profiles'
 
+/**
+ * Global SSE stream for the chat screen.
+ *
+ * This subscribes with no session key, so it receives every event on the bus —
+ * including task events, which are published under the shared 'all' key. It
+ * therefore needs the same two guards as /api/chat-events: authentication, and
+ * a per-user filter on task events (Issue #8 Phase 2). Without them this route
+ * streamed every user's task activity to any unauthenticated caller.
+ */
 export const Route = createFileRoute('/api/events')({
   server: {
     handlers: {
-      GET: async () => {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return new Response(
+            JSON.stringify({ ok: false, error: 'Unauthorized' }),
+            { status: 401, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+
+        const userId = getUserIdFromRequest(request)
+
         await ensureBusStarted()
 
         const encoder = new TextEncoder()
@@ -25,6 +48,7 @@ export const Route = createFileRoute('/api/events')({
 
             // Subscribe to chat event bus
             unsubscribe = subscribeToChatEvents((event) => {
+              if (!canSeeTaskEvent(userId, event.event, event.data)) return
               try {
                 controller.enqueue(
                   encoder.encode(

--- a/src/routes/api/events/replay.ts
+++ b/src/routes/api/events/replay.ts
@@ -10,8 +10,12 @@
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  getUserIdFromRequest,
+  isAuthenticated,
+} from '../../../server/auth-middleware'
 import { getEventsSince, getLatestSeq } from '../../../server/event-store'
+import { canSeeTaskEvent } from '../../../server/user-profiles'
 
 const MAX_LIMIT = 1_000
 
@@ -42,7 +46,13 @@ export const Route = createFileRoute('/api/events/replay')({
           MAX_LIMIT,
         )
 
-        const events = getEventsSince(sessionKey, since, limit)
+        // Per-user task-event filtering (Issue #8 Phase 2): task events live
+        // under the shared 'all' session key, so replaying them unfiltered
+        // dumped every user's task ids/titles to any authenticated caller.
+        const userId = getUserIdFromRequest(request)
+        const events = getEventsSince(sessionKey, since, limit).filter((ev) =>
+          canSeeTaskEvent(userId, ev.eventType, ev.payload),
+        )
         const latestSeq = getLatestSeq(sessionKey)
 
         return json({

--- a/src/routes/api/profiles/activate.ts
+++ b/src/routes/api/profiles/activate.ts
@@ -1,6 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  getUserIdFromRequest,
+  isAuthenticated,
+} from '../../../server/auth-middleware'
+import { canAccessProfileScoped } from '../../../server/user-profiles'
 import { setActiveProfile } from '../../../server/profiles-browser'
 import { requireJsonContentType } from '../../../server/rate-limit'
 
@@ -15,6 +19,11 @@ export const Route = createFileRoute('/api/profiles/activate')({
         if (csrfCheck) return csrfCheck
         try {
           const body = (await request.json()) as { name?: string }
+          if (!canAccessProfileScoped(getUserIdFromRequest(request), (body.name || '').trim())) {
+            // 404, not 403 — matches the task routes, so profile names of
+            // other accounts are not enumerable (Issue #8).
+            return json({ error: 'Profile not found' }, { status: 404 })
+          }
           setActiveProfile(body.name || '')
           return json({ ok: true })
         } catch (error) {

--- a/src/routes/api/profiles/create.ts
+++ b/src/routes/api/profiles/create.ts
@@ -1,6 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  getUserIdFromRequest,
+  isAuthenticated,
+} from '../../../server/auth-middleware'
+import { addProfileBinding } from '../../../server/user-profiles'
 import { createProfile } from '../../../server/profiles-browser'
 import { requireJsonContentType } from '../../../server/rate-limit'
 
@@ -20,14 +24,18 @@ export const Route = createFileRoute('/api/profiles/create')({
             model?: string
             provider?: string
           }
-          return json({
-            ok: true,
-            profile: createProfile(body.name || '', {
-              cloneFrom: body.cloneFrom,
-              model: body.model,
-              provider: body.provider,
-            }),
+          const profile = createProfile(body.name || '', {
+            cloneFrom: body.cloneFrom,
+            model: body.model,
+            provider: body.provider,
           })
+          // Bind the new profile to its creator, otherwise a regular admin
+          // creates a profile and immediately cannot see it (Issue #8).
+          const userId = getUserIdFromRequest(request)
+          if (userId) {
+            addProfileBinding(userId, (body.name || '').trim())
+          }
+          return json({ ok: true, profile })
         } catch (error) {
           return json(
             {

--- a/src/routes/api/profiles/delete.ts
+++ b/src/routes/api/profiles/delete.ts
@@ -1,6 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  getUserIdFromRequest,
+  isAuthenticated,
+} from '../../../server/auth-middleware'
+import { canAccessProfileScoped } from '../../../server/user-profiles'
 import { deleteProfile } from '../../../server/profiles-browser'
 import { requireJsonContentType } from '../../../server/rate-limit'
 
@@ -15,6 +19,11 @@ export const Route = createFileRoute('/api/profiles/delete')({
         if (csrfCheck) return csrfCheck
         try {
           const body = (await request.json()) as { name?: string }
+          if (!canAccessProfileScoped(getUserIdFromRequest(request), (body.name || '').trim())) {
+            // 404, not 403 — matches the task routes, so profile names of
+            // other accounts are not enumerable (Issue #8).
+            return json({ error: 'Profile not found' }, { status: 404 })
+          }
           deleteProfile(body.name || '')
           return json({ ok: true })
         } catch (error) {

--- a/src/routes/api/profiles/list.ts
+++ b/src/routes/api/profiles/list.ts
@@ -1,10 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  getUserIdFromRequest,
+  isAuthenticated,
+} from '../../../server/auth-middleware'
 import {
   getActiveProfileName,
   listProfiles,
 } from '../../../server/profiles-browser'
+import { filterAccessibleProfiles } from '../../../server/user-profiles'
 
 export const Route = createFileRoute('/api/profiles/list')({
   server: {
@@ -14,8 +18,11 @@ export const Route = createFileRoute('/api/profiles/list')({
           return json({ error: 'Unauthorized' }, { status: 401 })
         }
         try {
+          // Regular admins see only profiles bound to their account; super
+          // admins see all. Single-user installs are unaffected (Issue #8).
+          const userId = getUserIdFromRequest(request)
           return json({
-            profiles: listProfiles(),
+            profiles: filterAccessibleProfiles(userId, listProfiles()),
             activeProfile: getActiveProfileName(),
           })
         } catch (error) {

--- a/src/routes/api/profiles/read.ts
+++ b/src/routes/api/profiles/read.ts
@@ -1,6 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  getUserIdFromRequest,
+  isAuthenticated,
+} from '../../../server/auth-middleware'
+import { canAccessProfileScoped } from '../../../server/user-profiles'
 import { readProfile } from '../../../server/profiles-browser'
 
 export const Route = createFileRoute('/api/profiles/read')({
@@ -13,6 +17,11 @@ export const Route = createFileRoute('/api/profiles/read')({
         try {
           const url = new URL(request.url)
           const name = (url.searchParams.get('name') || '').trim() || 'default'
+          if (!canAccessProfileScoped(getUserIdFromRequest(request), name)) {
+            // 404, not 403 — matches the task routes, so profile names of
+            // other accounts are not enumerable (Issue #8).
+            return json({ error: 'Profile not found' }, { status: 404 })
+          }
           return json({ profile: readProfile(name) })
         } catch (error) {
           return json(

--- a/src/routes/api/profiles/rename.ts
+++ b/src/routes/api/profiles/rename.ts
@@ -1,6 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  getUserIdFromRequest,
+  isAuthenticated,
+} from '../../../server/auth-middleware'
+import { canAccessProfileScoped } from '../../../server/user-profiles'
 import { renameProfile } from '../../../server/profiles-browser'
 import { requireJsonContentType } from '../../../server/rate-limit'
 
@@ -17,6 +21,11 @@ export const Route = createFileRoute('/api/profiles/rename')({
           const body = (await request.json()) as {
             oldName?: string
             newName?: string
+          }
+          if (!canAccessProfileScoped(getUserIdFromRequest(request), (body.oldName || '').trim())) {
+            // 404, not 403 — matches the task routes, so profile names of
+            // other accounts are not enumerable (Issue #8).
+            return json({ error: 'Profile not found' }, { status: 404 })
           }
           return json({
             ok: true,

--- a/src/routes/api/tasks/$taskId.move.ts
+++ b/src/routes/api/tasks/$taskId.move.ts
@@ -3,12 +3,22 @@
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  getUserIdFromRequest,
+  isAuthenticated,
+} from '../../../server/auth-middleware'
 import { requireJsonContentType } from '../../../server/rate-limit'
-import { moveTask } from '../../../server/task-store'
+import { getTask, moveTask } from '../../../server/task-store'
+import { canAccessTask } from '../../../server/user-profiles'
 import type { TaskColumn } from '../../../types/task'
 
-const VALID_COLUMNS: TaskColumn[] = ['backlog', 'todo', 'in_progress', 'review', 'done']
+const VALID_COLUMNS: Array<TaskColumn> = [
+  'backlog',
+  'todo',
+  'in_progress',
+  'review',
+  'done',
+]
 
 export const Route = createFileRoute('/api/tasks/$taskId/move')({
   server: {
@@ -20,14 +30,29 @@ export const Route = createFileRoute('/api/tasks/$taskId/move')({
         const csrfCheck = requireJsonContentType(request)
         if (csrfCheck) return csrfCheck
 
-        const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+        const body = (await request.json().catch(() => ({}))) as Record<
+          string,
+          unknown
+        >
 
         const column = typeof body.column === 'string' ? body.column : ''
         if (!VALID_COLUMNS.includes(column as TaskColumn)) {
           return json(
-            { ok: false, error: `column must be one of: ${VALID_COLUMNS.join(', ')}` },
+            {
+              ok: false,
+              error: `column must be one of: ${VALID_COLUMNS.join(', ')}`,
+            },
             { status: 400 },
           )
+        }
+
+        const existing = getTask(params.taskId)
+        // 404 (not 403) on foreign tasks so task ids don't leak (Issue #8)
+        if (
+          !existing ||
+          !canAccessTask(getUserIdFromRequest(request), existing)
+        ) {
+          return json({ ok: false, error: 'Task not found' }, { status: 404 })
         }
 
         const task = moveTask(params.taskId, column as TaskColumn)

--- a/src/routes/api/tasks/$taskId.ts
+++ b/src/routes/api/tasks/$taskId.ts
@@ -5,13 +5,23 @@
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated } from '../../../server/auth-middleware'
+import {
+  getUserIdFromRequest,
+  isAuthenticated,
+} from '../../../server/auth-middleware'
 import { requireJsonContentType } from '../../../server/rate-limit'
-import { getTask, updateTask, deleteTask } from '../../../server/task-store'
+import { deleteTask, getTask, updateTask } from '../../../server/task-store'
+import { canAccessProfile, canAccessTask } from '../../../server/user-profiles'
 import type { TaskColumn, TaskPriority } from '../../../types/task'
 
-const VALID_COLUMNS: TaskColumn[] = ['backlog', 'todo', 'in_progress', 'review', 'done']
-const VALID_PRIORITIES: TaskPriority[] = ['high', 'medium', 'low']
+const VALID_COLUMNS: Array<TaskColumn> = [
+  'backlog',
+  'todo',
+  'in_progress',
+  'review',
+  'done',
+]
+const VALID_PRIORITIES: Array<TaskPriority> = ['high', 'medium', 'low']
 
 export const Route = createFileRoute('/api/tasks/$taskId')({
   server: {
@@ -21,7 +31,8 @@ export const Route = createFileRoute('/api/tasks/$taskId')({
           return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
         }
         const task = getTask(params.taskId)
-        if (!task) {
+        // 404 (not 403) on foreign tasks so task ids don't leak (Issue #8)
+        if (!task || !canAccessTask(getUserIdFromRequest(request), task)) {
           return json({ ok: false, error: 'Task not found' }, { status: 404 })
         }
         return json({ ok: true, task })
@@ -34,26 +45,64 @@ export const Route = createFileRoute('/api/tasks/$taskId')({
         const csrfCheck = requireJsonContentType(request)
         if (csrfCheck) return csrfCheck
 
-        const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+        const existing = getTask(params.taskId)
+        if (
+          !existing ||
+          !canAccessTask(getUserIdFromRequest(request), existing)
+        ) {
+          return json({ ok: false, error: 'Task not found' }, { status: 404 })
+        }
+
+        const body = (await request.json().catch(() => ({}))) as Record<
+          string,
+          unknown
+        >
 
         const updates: Parameters<typeof updateTask>[1] = {}
 
         if (typeof body.title === 'string') updates.title = body.title
-        if (typeof body.description === 'string') updates.description = body.description
-        if (typeof body.column === 'string' && VALID_COLUMNS.includes(body.column as TaskColumn)) {
+        if (typeof body.description === 'string')
+          updates.description = body.description
+        if (
+          typeof body.column === 'string' &&
+          VALID_COLUMNS.includes(body.column as TaskColumn)
+        ) {
           updates.column = body.column as TaskColumn
         }
-        if (typeof body.priority === 'string' && VALID_PRIORITIES.includes(body.priority as TaskPriority)) {
+        if (
+          typeof body.priority === 'string' &&
+          VALID_PRIORITIES.includes(body.priority as TaskPriority)
+        ) {
           updates.priority = body.priority as TaskPriority
         }
         if (typeof body.assignee === 'string' || body.assignee === null) {
-          updates.assignee = body.assignee as string | null
+          updates.assignee = body.assignee
         }
         if (Array.isArray(body.tags)) {
-          updates.tags = (body.tags as unknown[]).filter((t) => typeof t === 'string') as string[]
+          updates.tags = (body.tags as Array<unknown>).filter(
+            (t) => typeof t === 'string',
+          )
         }
         if (typeof body.dueDate === 'string' || body.dueDate === null) {
-          updates.dueDate = body.dueDate as string | null
+          updates.dueDate = body.dueDate
+        }
+
+        // Re-binding a task's profile (Issue #8 Phase 2d). Same rule as
+        // creation: you may only move a task into a profile you can access,
+        // otherwise re-binding would be a way to hand your own tasks to a
+        // profile you have no rights over. null unbinds.
+        if (typeof body.profileId === 'string' && body.profileId.trim()) {
+          const profileId = body.profileId.trim()
+          const userId = getUserIdFromRequest(request)
+          if (userId && !canAccessProfile(userId, profileId)) {
+            return json(
+              { ok: false, error: 'No access to that profile' },
+              { status: 403 },
+            )
+          }
+          updates.profileId = profileId
+        } else if (body.profileId === null) {
+          updates.profileId = null
         }
 
         const task = updateTask(params.taskId, updates)
@@ -66,6 +115,13 @@ export const Route = createFileRoute('/api/tasks/$taskId')({
       DELETE: async ({ request, params }) => {
         if (!isAuthenticated(request)) {
           return json({ ok: false, error: 'Unauthorized' }, { status: 401 })
+        }
+        const existing = getTask(params.taskId)
+        if (
+          !existing ||
+          !canAccessTask(getUserIdFromRequest(request), existing)
+        ) {
+          return json({ ok: false, error: 'Task not found' }, { status: 404 })
         }
         const deleted = deleteTask(params.taskId)
         if (!deleted) {

--- a/src/routes/api/tasks/index.ts
+++ b/src/routes/api/tasks/index.ts
@@ -4,15 +4,29 @@
  */
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
-import { isAuthenticated, getUserIdFromRequest } from '../../../server/auth-middleware'
+import {
+  getUserIdFromRequest,
+  isAuthenticated,
+} from '../../../server/auth-middleware'
 import { requireJsonContentType } from '../../../server/rate-limit'
-import { listTasks, createTask } from '../../../server/task-store'
-import { getUserProfile } from '../../../server/user-profiles'
-import type { TaskColumn, TaskPriority, TaskSourceType } from '../../../types/task'
+import { createTask, listTasks } from '../../../server/task-store'
+import { canAccessProfile, canAccessTask } from '../../../server/user-profiles'
+import { isMultiUserMode } from '../../../server/user-credentials'
+import type {
+  TaskColumn,
+  TaskPriority,
+  TaskSourceType,
+} from '../../../types/task'
 
-const VALID_COLUMNS: TaskColumn[] = ['backlog', 'todo', 'in_progress', 'review', 'done']
-const VALID_PRIORITIES: TaskPriority[] = ['high', 'medium', 'low']
-const VALID_SOURCES: TaskSourceType[] = ['manual', 'conductor', 'crew']
+const VALID_COLUMNS: Array<TaskColumn> = [
+  'backlog',
+  'todo',
+  'in_progress',
+  'review',
+  'done',
+]
+const VALID_PRIORITIES: Array<TaskPriority> = ['high', 'medium', 'low']
+const VALID_SOURCES: Array<TaskSourceType> = ['manual', 'conductor', 'crew']
 
 export const Route = createFileRoute('/api/tasks/')({
   server: {
@@ -39,7 +53,10 @@ export const Route = createFileRoute('/api/tasks/')({
         }
 
         const sourceType = url.searchParams.get('sourceType')
-        if (sourceType && VALID_SOURCES.includes(sourceType as TaskSourceType)) {
+        if (
+          sourceType &&
+          VALID_SOURCES.includes(sourceType as TaskSourceType)
+        ) {
           filter.sourceType = sourceType as TaskSourceType
         }
 
@@ -49,17 +66,18 @@ export const Route = createFileRoute('/api/tasks/')({
         // Get all tasks matching the filter
         let tasks = listTasks(filter)
 
-        // Apply role-based filtering (Issue #8)
-        // Super_admin users see all tasks
-        // Regular_admin users see only their own tasks (based on createdBy field)
+        // Role-based filtering (Issue #8): super admins see all tasks;
+        // regular admins see tasks they created or tasks of profiles bound
+        // to their account. In multi-user mode a session with no identity
+        // fails CLOSED instead of seeing everything.
         const userId = getUserIdFromRequest(request)
-        if (userId) {
-          const userProfile = getUserProfile(userId)
-          if (userProfile.role !== 'super_admin') {
-            // Filter to only tasks created by this user
-            tasks = tasks.filter((task) => task.createdBy === userId)
-          }
+        if (isMultiUserMode() && !userId) {
+          return json(
+            { ok: false, error: 'Session has no user identity — log in again' },
+            { status: 401 },
+          )
         }
+        tasks = tasks.filter((task) => canAccessTask(userId, task))
 
         return json({ ok: true, tasks })
       },
@@ -71,41 +89,78 @@ export const Route = createFileRoute('/api/tasks/')({
         const csrfCheck = requireJsonContentType(request)
         if (csrfCheck) return csrfCheck
 
-        const body = (await request.json().catch(() => ({}))) as Record<string, unknown>
+        const body = (await request.json().catch(() => ({}))) as Record<
+          string,
+          unknown
+        >
 
         const title = typeof body.title === 'string' ? body.title.trim() : ''
         if (!title) {
-          return json({ ok: false, error: 'title is required' }, { status: 400 })
+          return json(
+            { ok: false, error: 'title is required' },
+            { status: 400 },
+          )
         }
 
         const input: Parameters<typeof createTask>[0] = { title }
 
-        if (typeof body.description === 'string') input.description = body.description
-        if (typeof body.column === 'string' && VALID_COLUMNS.includes(body.column as TaskColumn)) {
+        if (typeof body.description === 'string')
+          input.description = body.description
+        if (
+          typeof body.column === 'string' &&
+          VALID_COLUMNS.includes(body.column as TaskColumn)
+        ) {
           input.column = body.column as TaskColumn
         }
-        if (typeof body.priority === 'string' && VALID_PRIORITIES.includes(body.priority as TaskPriority)) {
+        if (
+          typeof body.priority === 'string' &&
+          VALID_PRIORITIES.includes(body.priority as TaskPriority)
+        ) {
           input.priority = body.priority as TaskPriority
         }
         if (typeof body.assignee === 'string' || body.assignee === null) {
-          input.assignee = body.assignee as string | null
+          input.assignee = body.assignee
         }
         if (Array.isArray(body.tags)) {
-          input.tags = (body.tags as unknown[]).filter((t) => typeof t === 'string') as string[]
+          input.tags = (body.tags as Array<unknown>).filter(
+            (t) => typeof t === 'string',
+          )
         }
         if (typeof body.dueDate === 'string' || body.dueDate === null) {
-          input.dueDate = body.dueDate as string | null
+          input.dueDate = body.dueDate
         }
-        if (typeof body.sourceType === 'string' && VALID_SOURCES.includes(body.sourceType as TaskSourceType)) {
+        if (
+          typeof body.sourceType === 'string' &&
+          VALID_SOURCES.includes(body.sourceType as TaskSourceType)
+        ) {
           input.sourceType = body.sourceType as TaskSourceType
         }
         if (typeof body.sourceId === 'string' || body.sourceId === null) {
-          input.sourceId = body.sourceId as string | null
+          input.sourceId = body.sourceId
         }
 
         // Always set createdBy to the current user (cannot be overridden)
         const userId = getUserIdFromRequest(request)
+        if (isMultiUserMode() && !userId) {
+          return json(
+            { ok: false, error: 'Session has no user identity — log in again' },
+            { status: 401 },
+          )
+        }
         input.createdBy = userId || 'unknown'
+
+        // Optional profile assignment (Issue #8 Phase 2) — the creator must
+        // themselves have access to the profile they file the task under.
+        if (typeof body.profileId === 'string' && body.profileId.trim()) {
+          const profileId = body.profileId.trim()
+          if (userId && !canAccessProfile(userId, profileId)) {
+            return json(
+              { ok: false, error: 'No access to that profile' },
+              { status: 403 },
+            )
+          }
+          input.profileId = profileId
+        }
 
         const task = createTask(input)
         return json({ ok: true, task }, { status: 201 })

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -10,6 +10,7 @@ import {
   Settings02Icon,
   SourceCodeSquareIcon,
   SparklesIcon,
+  UserGroupIcon,
   UserIcon,
   VolumeHighIcon,
 } from '@hugeicons/core-free-icons'
@@ -34,6 +35,7 @@ import { Input } from '@/components/ui/input'
 import { LogoLoader } from '@/components/logo-loader'
 import { BrailleSpinner } from '@/components/ui/braille-spinner'
 import { ThreeDotsSpinner } from '@/components/ui/three-dots-spinner'
+import { UserAdminPanel } from '@/screens/settings/components/user-admin-panel'
 // useWorkspaceStore removed — hamburger eliminated on mobile
 
 export const Route = createFileRoute('/settings/')({
@@ -237,6 +239,7 @@ type SettingsSectionId =
   | 'integrations'
   | 'identity'
   | 'autostart'
+  | 'users'
   | 'advanced'
 
 type SettingsNavItem = {
@@ -258,6 +261,7 @@ const SETTINGS_NAV_ITEMS: Array<SettingsNavItem> = [
   { id: 'integrations', label: 'Integrations' },
   { id: 'identity', label: 'Identity' },
   { id: 'autostart', label: 'Auto-start' },
+  { id: 'users', label: 'Users & Access' },
   { id: 'mcp', label: 'MCP Servers', to: '/settings/mcp' },
 ]
 
@@ -393,6 +397,17 @@ function SettingsRoute() {
           )}
           {activeSection === 'permissions' && (
             <HermesConfigSection activeView="permissions" />
+          )}
+
+          {/* ── Users & Access (Issue #8) ────────────────────────── */}
+          {activeSection === 'users' && (
+            <SettingsSection
+              title="Users & Access"
+              description="Roles, profile bindings, and task ownership."
+              icon={UserGroupIcon}
+            >
+              <UserAdminPanel />
+            </SettingsSection>
           )}
 
           {/* ── Appearance ──────────────────────────────────────── */}

--- a/src/screens/settings/components/user-admin-panel.tsx
+++ b/src/screens/settings/components/user-admin-panel.tsx
@@ -1,0 +1,312 @@
+/**
+ * Users & Access — the UI half of Issue #8 Phase 2c/2d.
+ *
+ * /api/admin/users and /api/admin/orphan-tasks shipped with no interface at
+ * all, so promoting a super admin, binding a profile, or rescuing tasks
+ * stranded by the identity migration were curl-only operations. A permission
+ * system an operator cannot actually operate is not really shipped.
+ *
+ * Renders nothing outside multi-user mode (HERMES_USERS unset) — there are no
+ * users to manage and nothing is hidden — and shows a plain explanation rather
+ * than an empty box when the caller is not a super admin.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+
+type AdminUser = {
+  userId: string
+  role: 'super_admin' | 'regular_admin'
+  profileIds: Array<string>
+  envSuperAdmin: boolean
+}
+
+type OrphanTask = {
+  id: string
+  title: string
+  column: string
+  createdBy: string
+  profileId: string | null
+  createdAt: number
+}
+
+type LoadState = 'loading' | 'ready' | 'unavailable' | 'forbidden' | 'error'
+
+const CARD =
+  'rounded-xl border border-[var(--theme-border)] bg-[var(--theme-panel)]/60 p-3'
+
+export function UserAdminPanel() {
+  const [state, setState] = useState<LoadState>('loading')
+  const [message, setMessage] = useState('')
+  const [users, setUsers] = useState<Array<AdminUser>>([])
+  const [orphans, setOrphans] = useState<Array<OrphanTask>>([])
+  const [assignable, setAssignable] = useState<Array<string>>([])
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [assignTo, setAssignTo] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  const load = useCallback(async () => {
+    setState('loading')
+    try {
+      const res = await fetch('/api/admin/users')
+      const payload = (await res.json().catch(() => ({}))) as {
+        ok?: boolean
+        users?: Array<AdminUser>
+        error?: string
+      }
+
+      if (res.status === 400) {
+        // Single-user mode — not an error, just nothing to manage.
+        setState('unavailable')
+        setMessage(payload.error ?? '')
+        return
+      }
+      if (res.status === 403) {
+        setState('forbidden')
+        setMessage(payload.error ?? 'Requires super_admin')
+        return
+      }
+      if (!res.ok || payload.ok === false) {
+        setState('error')
+        setMessage(payload.error ?? `HTTP ${res.status}`)
+        return
+      }
+
+      setUsers(payload.users ?? [])
+
+      const orphanRes = await fetch('/api/admin/orphan-tasks')
+      const orphanPayload = (await orphanRes.json().catch(() => ({}))) as {
+        orphans?: Array<OrphanTask>
+        assignableUsers?: Array<string>
+      }
+      setOrphans(orphanPayload.orphans ?? [])
+      setAssignable(orphanPayload.assignableUsers ?? [])
+      setAssignTo(orphanPayload.assignableUsers?.[0] ?? '')
+      setSelected(new Set())
+      setState('ready')
+    } catch (err) {
+      setState('error')
+      setMessage(err instanceof Error ? err.message : String(err))
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  async function patchUser(userId: string, updates: Partial<AdminUser>) {
+    setBusy(true)
+    try {
+      const res = await fetch('/api/admin/users', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId, ...updates }),
+      })
+      const payload = (await res.json().catch(() => ({}))) as {
+        ok?: boolean
+        error?: string
+      }
+      if (!res.ok || payload.ok === false) {
+        setMessage(payload.error ?? `HTTP ${res.status}`)
+        return
+      }
+      setMessage('')
+      await load()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function reassignSelected() {
+    if (selected.size === 0 || !assignTo) return
+    setBusy(true)
+    try {
+      const res = await fetch('/api/admin/orphan-tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ taskIds: [...selected], createdBy: assignTo }),
+      })
+      const payload = (await res.json().catch(() => ({}))) as {
+        ok?: boolean
+        reassigned?: Array<string>
+        skipped?: Array<string>
+        error?: string
+      }
+      if (!res.ok || payload.ok === false) {
+        setMessage(payload.error ?? `HTTP ${res.status}`)
+        return
+      }
+      const skipped = payload.skipped?.length ?? 0
+      setMessage(
+        `Reassigned ${payload.reassigned?.length ?? 0} task(s) to ${assignTo}` +
+          (skipped > 0 ? ` — ${skipped} skipped (no longer orphaned)` : ''),
+      )
+      await load()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (state === 'loading') {
+    return <p className="text-sm text-[var(--theme-muted)]">Loading users…</p>
+  }
+
+  // Single-user mode: say so plainly instead of rendering an empty panel.
+  if (state === 'unavailable') {
+    return (
+      <p className="text-sm text-[var(--theme-muted)]">
+        {message ||
+          'Multi-user mode is off. Set HERMES_USERS to enable per-user logins and task visibility.'}
+      </p>
+    )
+  }
+
+  if (state === 'forbidden') {
+    return (
+      <p className="text-sm text-[var(--theme-muted)]">
+        {message}. Ask a super admin to change roles or profile bindings.
+      </p>
+    )
+  }
+
+  if (state === 'error') {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-red-400">{message}</p>
+        <Button variant="secondary" onClick={() => void load()}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        {users.map((user) => (
+          <div key={user.userId} className={CARD}>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-[var(--theme-text)]">
+                  {user.userId}
+                </p>
+                <p className="text-xs text-[var(--theme-muted)]">
+                  {user.profileIds.length > 0
+                    ? `Profiles: ${user.profileIds.join(', ')}`
+                    : 'No profile bindings'}
+                </p>
+              </div>
+              <div className="flex items-center gap-2">
+                <select
+                  value={user.role}
+                  disabled={busy || user.envSuperAdmin}
+                  onChange={(e) =>
+                    void patchUser(user.userId, {
+                      role: e.target.value as AdminUser['role'],
+                    })
+                  }
+                  className="h-8 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 text-xs text-[var(--theme-text)] disabled:opacity-50"
+                  aria-label={`Role for ${user.userId}`}
+                >
+                  <option value="regular_admin">Regular admin</option>
+                  <option value="super_admin">Super admin</option>
+                </select>
+              </div>
+            </div>
+            {user.envSuperAdmin ? (
+              <p className="mt-1 text-xs text-[var(--theme-muted)]">
+                Super admin via HERMES_SUPER_ADMINS — re-granted at every login,
+                so demoting here would not stick.
+              </p>
+            ) : null}
+            <label className="mt-2 block">
+              <span className="sr-only">Profile bindings for {user.userId}</span>
+              <input
+                type="text"
+                defaultValue={user.profileIds.join(', ')}
+                disabled={busy}
+                placeholder="Profile bindings, comma-separated"
+                onBlur={(e) => {
+                  const next = e.target.value
+                    .split(',')
+                    .map((s) => s.trim())
+                    .filter(Boolean)
+                  if (next.join(',') === user.profileIds.join(',')) return
+                  void patchUser(user.userId, { profileIds: next })
+                }}
+                className="h-8 w-full rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 text-xs text-[var(--theme-text)]"
+              />
+            </label>
+          </div>
+        ))}
+      </div>
+
+      {orphans.length > 0 ? (
+        <div className={CARD}>
+          <p className="text-sm font-medium text-[var(--theme-text)]">
+            {orphans.length} task(s) belong to nobody
+          </p>
+          <p className="mb-2 text-xs text-[var(--theme-muted)]">
+            Created before per-user logins were enabled, so no regular admin can
+            see them. Assign them to a real account to bring them back onto that
+            user&apos;s board.
+          </p>
+          <div className="max-h-48 space-y-1 overflow-y-auto">
+            {orphans.map((task) => (
+              <label
+                key={task.id}
+                className="flex items-center gap-2 text-xs text-[var(--theme-text)]"
+              >
+                <input
+                  type="checkbox"
+                  checked={selected.has(task.id)}
+                  onChange={(e) => {
+                    const next = new Set(selected)
+                    if (e.target.checked) next.add(task.id)
+                    else next.delete(task.id)
+                    setSelected(next)
+                  }}
+                />
+                <span className="truncate">{task.title}</span>
+                <span className="shrink-0 text-[var(--theme-muted)]">
+                  ({task.column} · was &quot;{task.createdBy}&quot;)
+                </span>
+              </label>
+            ))}
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <Button
+              variant="secondary"
+              onClick={() => setSelected(new Set(orphans.map((t) => t.id)))}
+              disabled={busy}
+            >
+              Select all
+            </Button>
+            <select
+              value={assignTo}
+              onChange={(e) => setAssignTo(e.target.value)}
+              disabled={busy}
+              className="h-8 rounded-lg border border-[var(--theme-border)] bg-[var(--theme-bg)] px-2 text-xs text-[var(--theme-text)]"
+              aria-label="Assign orphaned tasks to"
+            >
+              {assignable.map((u) => (
+                <option key={u} value={u}>
+                  {u}
+                </option>
+              ))}
+            </select>
+            <Button
+              onClick={() => void reassignSelected()}
+              disabled={busy || selected.size === 0 || !assignTo}
+            >
+              Assign {selected.size > 0 ? `${selected.size} ` : ''}to {assignTo}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {message ? (
+        <p className="text-xs text-[var(--theme-muted)]">{message}</p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/server/auth-middleware.ts
+++ b/src/server/auth-middleware.ts
@@ -1,5 +1,6 @@
 import { randomBytes, timingSafeEqual } from 'node:crypto'
 import { getRedisClient, getRedisClientSync } from './redis-client'
+import { isMultiUserMode } from './user-credentials'
 
 const TOKENS_KEY = 'hermes:studio:tokens'
 const TOKEN_USER_KEY = 'hermes:studio:token:user'
@@ -88,11 +89,16 @@ export function revokeSessionToken(token: string): void {
 }
 
 /**
- * Check if password protection is enabled.
+ * Check if password protection is enabled — either the legacy shared
+ * HERMES_PASSWORD or per-user HERMES_USERS credentials (Issue #8 Phase 2).
+ * Multi-user mode MUST count as protected: it exists to isolate users, so
+ * "no shared password → no auth" would let anyone in with no identity.
  */
 export function isPasswordProtectionEnabled(): boolean {
-  return Boolean(
-    process.env.HERMES_PASSWORD && process.env.HERMES_PASSWORD.length > 0,
+  return (
+    Boolean(
+      process.env.HERMES_PASSWORD && process.env.HERMES_PASSWORD.length > 0,
+    ) || isMultiUserMode()
   )
 }
 

--- a/src/server/task-store.ts
+++ b/src/server/task-store.ts
@@ -8,14 +8,14 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { randomUUID } from 'node:crypto'
+import { publishChatEvent } from './chat-event-bus'
 import type {
-  HermesTask,
   CreateTaskInput,
-  UpdateTaskInput,
+  HermesTask,
   TaskColumn,
   TaskSourceType,
+  UpdateTaskInput,
 } from '../types/task'
-import { publishChatEvent } from './chat-event-bus'
 
 const DATA_DIR = join(process.cwd(), '.runtime')
 const TASKS_FILE = join(DATA_DIR, 'tasks.json')
@@ -59,7 +59,7 @@ function scheduleSave(): void {
 
 loadFromDisk()
 
-export function listTasks(filter?: TaskFilter): HermesTask[] {
+export function listTasks(filter?: TaskFilter): Array<HermesTask> {
   let tasks = Object.values(store.tasks)
   if (filter?.column) tasks = tasks.filter((t) => t.column === filter.column)
   if (filter?.assignee) tasks = tasks.filter((t) => t.assignee === filter.assignee)
@@ -88,12 +88,22 @@ export function createTask(input: CreateTaskInput): HermesTask {
     sourceType: input.sourceType ?? 'manual',
     sourceId: input.sourceId ?? null,
     createdBy: input.createdBy ?? 'user',
+    profileId: input.profileId ?? null,
     createdAt: now,
     updatedAt: now,
   }
   store.tasks[task.id] = task
   saveToDisk()
-  publishChatEvent('task.created', { sessionKey: 'all', taskId: task.id, title: task.title, sourceType: task.sourceType })
+  // createdBy/profileId ride along so role-aware event surfaces can filter
+  // task events per user without a store lookup (Issue #8 Phase 2).
+  publishChatEvent('task.created', {
+    sessionKey: 'all',
+    taskId: task.id,
+    title: task.title,
+    sourceType: task.sourceType,
+    createdBy: task.createdBy,
+    profileId: task.profileId ?? null,
+  })
   return task
 }
 
@@ -108,6 +118,30 @@ export function updateTask(taskId: string, updates: UpdateTaskInput): HermesTask
   if (updates.tags !== undefined) task.tags = updates.tags
   if (updates.dueDate !== undefined) task.dueDate = updates.dueDate
   if (updates.position !== undefined) task.position = updates.position
+  if (updates.profileId !== undefined) task.profileId = updates.profileId
+  task.updatedAt = Date.now()
+  scheduleSave()
+  return task
+}
+
+/**
+ * Reassign a task's creator (Issue #8 Phase 2d migration).
+ *
+ * `createdBy` is deliberately not part of UpdateTaskInput — the task routes
+ * always stamp it from the session so it cannot be spoofed. This is the one
+ * sanctioned way to change it, and the caller must supply a predicate saying
+ * which current owners are eligible, so the super-admin migration endpoint
+ * cannot be used to take over a task that already belongs to a real user.
+ */
+export function updateTaskOwner(
+  taskId: string,
+  createdBy: string,
+  isEligible: (currentOwner: string) => boolean,
+): HermesTask | null {
+  const task = store.tasks[taskId]
+  if (!task) return null
+  if (!isEligible(task.createdBy)) return null
+  task.createdBy = createdBy
   task.updatedAt = Date.now()
   scheduleSave()
   return task
@@ -116,15 +150,28 @@ export function updateTask(taskId: string, updates: UpdateTaskInput): HermesTask
 export function moveTask(taskId: string, column: TaskColumn): HermesTask | null {
   const result = updateTask(taskId, { column })
   if (result) {
-    publishChatEvent('task.moved', { sessionKey: 'all', taskId, column })
+    publishChatEvent('task.moved', {
+      sessionKey: 'all',
+      taskId,
+      column,
+      createdBy: result.createdBy,
+      profileId: result.profileId ?? null,
+    })
   }
   return result
 }
 
 export function deleteTask(taskId: string): boolean {
-  if (!store.tasks[taskId]) return false
+  const task = store.tasks[taskId]
+  if (!task) return false
   delete store.tasks[taskId]
   saveToDisk()
-  publishChatEvent('task.deleted', { sessionKey: 'all', taskId })
+  // The task is gone — carry its last ownership so filters still apply.
+  publishChatEvent('task.deleted', {
+    sessionKey: 'all',
+    taskId,
+    createdBy: task.createdBy,
+    profileId: task.profileId ?? null,
+  })
   return true
 }

--- a/src/server/user-credentials.ts
+++ b/src/server/user-credentials.ts
@@ -1,0 +1,80 @@
+/**
+ * Multi-user credentials (Issue #8, Phase 2a).
+ *
+ * Single-user mode (default): only HERMES_PASSWORD is set — one shared
+ * password, no identity, no per-user task filtering. Unchanged behavior.
+ *
+ * Multi-user mode: HERMES_USERS is set to a comma-separated list of
+ * username:password pairs (password may contain colons; the split is on the
+ * FIRST colon only):
+ *
+ *   HERMES_USERS='alice:s3cret,bob:hunter2'
+ *   HERMES_SUPER_ADMINS='alice'
+ *
+ * In this mode logins require a username, every session token carries the
+ * userId, and task access fails CLOSED for requests with no identity —
+ * misconfiguration must not silently reopen the all-tasks leak the issue
+ * reported. Usernames in HERMES_SUPER_ADMINS are (re-)granted the
+ * super_admin role at login; other users keep their stored role, defaulting
+ * to regular_admin.
+ */
+import { timingSafeEqual } from 'node:crypto'
+
+function parseUsers(): Map<string, string> {
+  const raw = process.env.HERMES_USERS ?? ''
+  const users = new Map<string, string>()
+  for (const entry of raw.split(',')) {
+    const trimmed = entry.trim()
+    if (!trimmed) continue
+    const colonIdx = trimmed.indexOf(':')
+    if (colonIdx <= 0) continue
+    const username = trimmed.slice(0, colonIdx).trim()
+    const password = trimmed.slice(colonIdx + 1)
+    if (username && password) users.set(username, password)
+  }
+  return users
+}
+
+export function isMultiUserMode(): boolean {
+  return parseUsers().size > 0
+}
+
+export function listConfiguredUsernames(): Array<string> {
+  return Array.from(parseUsers().keys())
+}
+
+function timingSafeStringEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf8')
+  const bBuf = Buffer.from(b, 'utf8')
+  if (aBuf.length !== bBuf.length) return false
+  try {
+    return timingSafeEqual(aBuf, bBuf)
+  } catch {
+    return false
+  }
+}
+
+/** Verify a username/password pair against HERMES_USERS. */
+export function verifyUserPassword(
+  username: string,
+  password: string,
+): boolean {
+  const users = parseUsers()
+  const expected = users.get(username)
+  if (!expected) {
+    // Compare against a dummy value so unknown usernames cost the same time.
+    timingSafeStringEqual(password, 'hermes-studio-dummy-password')
+    return false
+  }
+  return timingSafeStringEqual(password, expected)
+}
+
+/** Usernames granted super_admin at login via HERMES_SUPER_ADMINS. */
+export function superAdminUsernames(): Set<string> {
+  return new Set(
+    (process.env.HERMES_SUPER_ADMINS ?? '')
+      .split(',')
+      .map((name) => name.trim())
+      .filter(Boolean),
+  )
+}

--- a/src/server/user-profiles.ts
+++ b/src/server/user-profiles.ts
@@ -3,13 +3,14 @@
  * Tracks user roles (super_admin vs regular_admin) and profile bindings.
  */
 import { getRedisClient, getRedisClientSync } from './redis-client'
+import { isMultiUserMode } from './user-credentials'
 
 export type UserRole = 'super_admin' | 'regular_admin'
 
 export interface UserProfile {
   userId: string
   role: UserRole
-  profileIds: string[] // Profiles this user can access
+  profileIds: Array<string> // Profiles this user can access
 }
 
 const USERS_KEY = 'hermes:studio:users'
@@ -111,10 +112,101 @@ export function canAccessProfile(userId: string, profileId: string): boolean {
 }
 
 /**
- * Get all profiles a user can access.
+ * Get all profiles a user can access. `null` means unrestricted (super
+ * admin) — callers must treat null as "all", never as "none". The previous
+ * `[]` sentinel read as "no access" to naive callers and would have
+ * silently inverted the rule (Issue #8 Phase 2).
  */
-export function getAccessibleProfiles(userId: string): string[] {
+export function getAccessibleProfiles(userId: string): Array<string> | null {
   const profile = getUserProfile(userId)
-  if (profile.role === 'super_admin') return [] // null = all profiles
+  if (profile.role === 'super_admin') return null
   return profile.profileIds
+}
+
+/**
+ * Identity-aware profile check for the /api/profiles/* routes, with the same
+ * open/closed rule as canAccessTask(): single-user installs keep the legacy
+ * behaviour (everything visible), multi-user installs fail closed.
+ *
+ * The issue's expected behaviour is "regular administrators should only see
+ * profiles bound to their account", but nothing enforced it: every
+ * /api/profiles route checked only isAuthenticated, and getAccessibleProfiles
+ * had no production callers at all. Task-level filtering was correct while any
+ * regular admin could still list, read, rename, delete and activate every
+ * profile in the install.
+ */
+export function canAccessProfileScoped(
+  userId: string | null | undefined,
+  profileId: string,
+): boolean {
+  if (!userId) return !isMultiUserMode()
+  return canAccessProfile(userId, profileId)
+}
+
+/**
+ * Filter a list of profile names to those the user may see. `null` from
+ * getAccessibleProfiles() means unrestricted — returning `[]` for a super
+ * admin would invert the rule and hide everything from the one account that
+ * is supposed to see all of it.
+ */
+export function filterAccessibleProfiles<T extends { name: string }>(
+  userId: string | null | undefined,
+  profiles: Array<T>,
+): Array<T> {
+  if (!userId) return isMultiUserMode() ? [] : profiles
+  const allowed = getAccessibleProfiles(userId)
+  if (allowed === null) return profiles
+  const allowedSet = new Set(allowed)
+  return profiles.filter((p) => allowedSet.has(p.name))
+}
+
+/**
+ * Check if a user may act on a task. Super admins may act on any task;
+ * regular admins on tasks they created or tasks belonging to a profile
+ * bound to their account (Issue #8 Phase 2).
+ *
+ * A missing userId means:
+ *  - single-user mode: no per-user filtering — allow (legacy behavior);
+ *  - multi-user mode (HERMES_USERS set): DENY. Identity should always be
+ *    present here; failing open would silently reopen the all-tasks leak.
+ */
+export function canAccessTask(
+  userId: string | null | undefined,
+  task: { createdBy?: string | null; profileId?: string | null },
+): boolean {
+  if (!userId) return !isMultiUserMode()
+  const profile = getUserProfile(userId)
+  if (profile.role === 'super_admin') return true
+  if (task.createdBy === userId) return true
+  if (task.profileId && profile.profileIds.includes(task.profileId)) return true
+  return false
+}
+
+/**
+ * Whether a user may see a task event (task.created/moved/deleted) on the
+ * event surfaces (/api/chat-events, /api/events/replay, /api/audit). Task
+ * events are published under the shared session key 'all', so without this
+ * check any authenticated user would watch every user's task activity
+ * (Issue #8 Phase 2).
+ *
+ * Payloads carry createdBy/profileId since Phase 2; older stored events
+ * don't — those are visible only to super admins / single-user mode
+ * (fail closed for regular admins).
+ */
+export function canSeeTaskEvent(
+  userId: string | null | undefined,
+  eventType: string,
+  payload: unknown,
+): boolean {
+  if (!eventType.startsWith('task.')) return true
+  if (!userId) return !isMultiUserMode()
+  const profile = getUserProfile(userId)
+  if (profile.role === 'super_admin') return true
+  if (!payload || typeof payload !== 'object') return false
+  const record = payload as { createdBy?: unknown; profileId?: unknown }
+  if (typeof record.createdBy !== 'string') return false
+  return canAccessTask(userId, {
+    createdBy: record.createdBy,
+    profileId: typeof record.profileId === 'string' ? record.profileId : null,
+  })
 }

--- a/src/test/events-route.test.ts
+++ b/src/test/events-route.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Route } from '@/routes/api/events'
+import {
+  generateSessionToken,
+  revokeSessionToken,
+  storeSessionToken,
+} from '@/server/auth-middleware'
+import { publishChatEvent } from '@/server/chat-event-bus'
+import { updateUserProfile } from '@/server/user-profiles'
+
+// Suppress Redis interactions triggered on module load (same approach as
+// auth-middleware.test.ts) and keep the event store off the filesystem —
+// the bus only needs appendEvent, and `null` means "no seq available".
+// vi.mock calls are hoisted above the imports at transform time.
+vi.mock('@/server/redis-client', () => ({
+  getRedisClient: () => Promise.resolve(null),
+  getRedisClientSync: () => null,
+}))
+
+vi.mock('@/server/event-store', () => ({
+  appendEvent: vi.fn(() => null),
+}))
+
+const GET = (
+  Route.options as unknown as {
+    server: {
+      handlers: { GET: (ctx: { request: Request }) => Promise<Response> }
+    }
+  }
+).server.handlers.GET
+
+function makeRequest(cookie?: string): Request {
+  const headers: Record<string, string> = {}
+  if (cookie) headers['cookie'] = cookie
+  return new Request('http://localhost/api/events', { headers })
+}
+
+const decoder = new TextDecoder()
+
+/** Read the next SSE chunk, failing fast instead of hanging the test. */
+async function nextChunk(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<string> {
+  const result = await Promise.race([
+    reader.read(),
+    new Promise<never>((_, reject) =>
+      setTimeout(
+        () => reject(new Error('timed out waiting for SSE chunk')),
+        1_000,
+      ),
+    ),
+  ])
+  return result.done ? '' : decoder.decode(result.value, { stream: true })
+}
+
+beforeEach(() => {
+  delete process.env.HERMES_PASSWORD
+  delete process.env.HERMES_USER_ID
+})
+
+afterEach(() => {
+  delete process.env.HERMES_PASSWORD
+  delete process.env.HERMES_USER_ID
+})
+
+/** Open an authenticated stream for `userId` and consume the connected event. */
+async function openStream(userId: string) {
+  const token = generateSessionToken()
+  storeSessionToken(token, userId)
+  const res = await GET({ request: makeRequest(`hermes-auth=${token}`) })
+  expect(res.status).toBe(200)
+  const reader = res.body!.getReader()
+  expect(await nextChunk(reader)).toContain('event: connected')
+  return {
+    reader,
+    close: async () => {
+      await reader.cancel()
+      revokeSessionToken(token)
+    },
+  }
+}
+
+describe('GET /api/events', () => {
+  it('returns 401 when password protection is enabled and request is unauthenticated', async () => {
+    process.env.HERMES_PASSWORD = 'secret'
+    const res = await GET({ request: makeRequest() })
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ ok: false, error: 'Unauthorized' })
+  })
+
+  it('returns 401 for an invalid session token', async () => {
+    process.env.HERMES_PASSWORD = 'secret'
+    const res = await GET({
+      request: makeRequest('hermes-auth=not-a-real-token'),
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('streams a connected event for an authenticated session', async () => {
+    process.env.HERMES_PASSWORD = 'secret'
+    const stream = await openStream('user-connected')
+    // openStream already asserted status 200 + the connected event
+    await stream.close()
+  })
+
+  it('streams task events unfiltered in single-user mode (no password, no user)', async () => {
+    const res = await GET({ request: makeRequest() })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream')
+    const reader = res.body!.getReader()
+    expect(await nextChunk(reader)).toContain('event: connected')
+
+    publishChatEvent('task.created', {
+      sessionKey: 'all',
+      taskId: 'task-single',
+      title: 'Anyone sees this',
+      createdBy: 'somebody-else',
+    })
+    const chunk = await nextChunk(reader)
+    expect(chunk).toContain('event: task.created')
+    expect(chunk).toContain('task-single')
+    await reader.cancel()
+  })
+
+  it('hides other users’ task events from regular admins', async () => {
+    process.env.HERMES_PASSWORD = 'secret'
+    // Regular admin by default (no profile stored for this user)
+    const stream = await openStream('regular-user')
+
+    publishChatEvent('task.created', {
+      sessionKey: 'all',
+      taskId: 'task-other',
+      title: 'Not yours',
+      createdBy: 'someone-else',
+    })
+    // Marker event proves the filtered event was dropped rather than delayed:
+    // non-task events pass through, so the next chunk must be the marker.
+    publishChatEvent('marker', { sessionKey: 'all' })
+
+    const chunk = await nextChunk(stream.reader)
+    expect(chunk).toContain('event: marker')
+    expect(chunk).not.toContain('task-other')
+    await stream.close()
+  })
+
+  it('delivers a regular admin’s own task events', async () => {
+    process.env.HERMES_PASSWORD = 'secret'
+    const stream = await openStream('owner-user')
+
+    publishChatEvent('task.moved', {
+      sessionKey: 'all',
+      taskId: 'task-mine',
+      column: 'done',
+      createdBy: 'owner-user',
+    })
+    const chunk = await nextChunk(stream.reader)
+    expect(chunk).toContain('event: task.moved')
+    expect(chunk).toContain('task-mine')
+    await stream.close()
+  })
+
+  it('hides task events without createdBy from regular admins', async () => {
+    process.env.HERMES_PASSWORD = 'secret'
+    const stream = await openStream('regular-user-2')
+
+    // Legacy/orphan events carry no createdBy — same invisibility as the
+    // /api/tasks list filter gives orphan tasks for non-super-admins.
+    publishChatEvent('task.deleted', {
+      sessionKey: 'all',
+      taskId: 'task-orphan',
+    })
+    publishChatEvent('marker', { sessionKey: 'all' })
+
+    const chunk = await nextChunk(stream.reader)
+    expect(chunk).toContain('event: marker')
+    expect(chunk).not.toContain('task-orphan')
+    await stream.close()
+  })
+
+  it('delivers all task events to super admins', async () => {
+    process.env.HERMES_PASSWORD = 'secret'
+    updateUserProfile('super-user', { role: 'super_admin' })
+    const stream = await openStream('super-user')
+
+    publishChatEvent('task.deleted', {
+      sessionKey: 'all',
+      taskId: 'task-any',
+      createdBy: 'someone-else',
+    })
+    const chunk = await nextChunk(stream.reader)
+    expect(chunk).toContain('event: task.deleted')
+    expect(chunk).toContain('task-any')
+    await stream.close()
+  })
+})

--- a/src/test/multi-user.test.ts
+++ b/src/test/multi-user.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  isMultiUserMode,
+  listConfiguredUsernames,
+  superAdminUsernames,
+  verifyUserPassword,
+} from '../server/user-credentials'
+import {
+  addProfileBinding,
+  canAccessProfileScoped,
+  canAccessTask,
+  canSeeTaskEvent,
+  filterAccessibleProfiles,
+  getAccessibleProfiles,
+  updateUserProfile,
+} from '../server/user-profiles'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('user-credentials (Issue #8 Phase 2a)', () => {
+  it('is single-user mode when HERMES_USERS is unset', () => {
+    expect(isMultiUserMode()).toBe(false)
+    expect(listConfiguredUsernames()).toEqual([])
+  })
+
+  it('parses HERMES_USERS pairs, splitting on the first colon only', () => {
+    vi.stubEnv('HERMES_USERS', 'alice:s3cret, bob:pw:with:colons ,broken')
+    expect(isMultiUserMode()).toBe(true)
+    expect(listConfiguredUsernames()).toEqual(['alice', 'bob'])
+    expect(verifyUserPassword('alice', 's3cret')).toBe(true)
+    expect(verifyUserPassword('bob', 'pw:with:colons')).toBe(true)
+    expect(verifyUserPassword('alice', 'wrong')).toBe(false)
+    expect(verifyUserPassword('nobody', 's3cret')).toBe(false)
+  })
+
+  it('reads super admin usernames from HERMES_SUPER_ADMINS', () => {
+    vi.stubEnv('HERMES_SUPER_ADMINS', 'alice, carol')
+    const supers = superAdminUsernames()
+    expect(supers.has('alice')).toBe(true)
+    expect(supers.has('carol')).toBe(true)
+    expect(supers.has('bob')).toBe(false)
+  })
+})
+
+describe('canAccessTask in multi-user mode (fail closed)', () => {
+  it('denies identity-less requests when HERMES_USERS is set', () => {
+    vi.stubEnv('HERMES_USERS', 'alice:pw')
+    expect(canAccessTask(null, { createdBy: 'alice' })).toBe(false)
+    expect(canAccessTask(undefined, { createdBy: 'alice' })).toBe(false)
+  })
+
+  it('still allows identity-less requests in single-user mode', () => {
+    expect(canAccessTask(null, { createdBy: 'anyone' })).toBe(true)
+  })
+})
+
+describe('profile-bound task access (Issue #8 Phase 2d)', () => {
+  it('grants a regular admin access via a bound profile', () => {
+    updateUserProfile('binder', { role: 'regular_admin', profileIds: [] })
+    addProfileBinding('binder', 'profile-x')
+    expect(
+      canAccessTask('binder', { createdBy: 'other', profileId: 'profile-x' }),
+    ).toBe(true)
+    expect(
+      canAccessTask('binder', { createdBy: 'other', profileId: 'profile-y' }),
+    ).toBe(false)
+    expect(canAccessTask('binder', { createdBy: 'other' })).toBe(false)
+  })
+
+  it('returns null (= all profiles) for super admins, not []', () => {
+    updateUserProfile('root-user', { role: 'super_admin' })
+    expect(getAccessibleProfiles('root-user')).toBeNull()
+    updateUserProfile('plain-user', {
+      role: 'regular_admin',
+      profileIds: ['p1'],
+    })
+    expect(getAccessibleProfiles('plain-user')).toEqual(['p1'])
+  })
+})
+
+describe('canSeeTaskEvent (Issue #8 Phase 2b)', () => {
+  it('passes non-task events through untouched', () => {
+    expect(canSeeTaskEvent('anyone', 'tool', {})).toBe(true)
+    expect(canSeeTaskEvent(null, 'user_message', {})).toBe(true)
+  })
+
+  it('lets owners and super admins see task events', () => {
+    updateUserProfile('ev-super', { role: 'super_admin' })
+    updateUserProfile('ev-owner', { role: 'regular_admin', profileIds: [] })
+    const payload = { taskId: 't1', createdBy: 'ev-owner', profileId: null }
+    expect(canSeeTaskEvent('ev-owner', 'task.created', payload)).toBe(true)
+    expect(canSeeTaskEvent('ev-super', 'task.created', payload)).toBe(true)
+  })
+
+  it('hides foreign task events from regular admins', () => {
+    updateUserProfile('ev-other', { role: 'regular_admin', profileIds: [] })
+    expect(
+      canSeeTaskEvent('ev-other', 'task.moved', {
+        taskId: 't1',
+        createdBy: 'someone-else',
+      }),
+    ).toBe(false)
+  })
+
+  it('fails closed on legacy payloads without createdBy', () => {
+    updateUserProfile('ev-legacy', { role: 'regular_admin', profileIds: [] })
+    expect(canSeeTaskEvent('ev-legacy', 'task.deleted', { taskId: 't9' })).toBe(
+      false,
+    )
+    updateUserProfile('ev-root', { role: 'super_admin' })
+    expect(canSeeTaskEvent('ev-root', 'task.deleted', { taskId: 't9' })).toBe(
+      true,
+    )
+  })
+
+  it('grants event visibility through profile bindings', () => {
+    updateUserProfile('ev-bound', {
+      role: 'regular_admin',
+      profileIds: ['team-a'],
+    })
+    expect(
+      canSeeTaskEvent('ev-bound', 'task.created', {
+        taskId: 't2',
+        createdBy: 'someone-else',
+        profileId: 'team-a',
+      }),
+    ).toBe(true)
+  })
+
+  it('denies identity-less callers in multi-user mode', () => {
+    vi.stubEnv('HERMES_USERS', 'alice:pw')
+    expect(
+      canSeeTaskEvent(undefined, 'task.created', {
+        taskId: 't3',
+        createdBy: 'alice',
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('profile visibility (Issue #8 — the issue\'s literal ask)', () => {
+  it('is unrestricted in single-user mode, with or without an identity', () => {
+    const profiles = [{ name: 'default' }, { name: 'research' }]
+    expect(canAccessProfileScoped(null, 'research')).toBe(true)
+    expect(canAccessProfileScoped(undefined, 'research')).toBe(true)
+    expect(filterAccessibleProfiles(null, profiles)).toEqual(profiles)
+  })
+
+  it('fails closed for identity-less requests in multi-user mode', () => {
+    vi.stubEnv('HERMES_USERS', 'alice:pw')
+    expect(canAccessProfileScoped(null, 'research')).toBe(false)
+    expect(filterAccessibleProfiles(null, [{ name: 'research' }])).toEqual([])
+  })
+
+  it('shows a regular admin only the profiles bound to their account', () => {
+    vi.stubEnv('HERMES_USERS', 'bob:pw')
+    updateUserProfile('profile-bob', { role: 'regular_admin', profileIds: [] })
+    addProfileBinding('profile-bob', 'research')
+
+    expect(canAccessProfileScoped('profile-bob', 'research')).toBe(true)
+    expect(canAccessProfileScoped('profile-bob', 'secret')).toBe(false)
+    expect(
+      filterAccessibleProfiles('profile-bob', [
+        { name: 'default' },
+        { name: 'research' },
+        { name: 'secret' },
+      ]),
+    ).toEqual([{ name: 'research' }])
+  })
+
+  it('shows a super admin every profile — null must not read as "none"', () => {
+    vi.stubEnv('HERMES_USERS', 'alice:pw')
+    updateUserProfile('profile-alice', { role: 'super_admin', profileIds: [] })
+
+    expect(getAccessibleProfiles('profile-alice')).toBeNull()
+    expect(canAccessProfileScoped('profile-alice', 'anything')).toBe(true)
+    const all = [{ name: 'default' }, { name: 'research' }]
+    expect(filterAccessibleProfiles('profile-alice', all)).toEqual(all)
+  })
+})

--- a/src/test/route-auth-coverage.test.ts
+++ b/src/test/route-auth-coverage.test.ts
@@ -1,0 +1,75 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Regression guard for the /api/events auth gap.
+ *
+ * /api/events shipped with no auth check at all, streaming every event on the
+ * bus — including task events, which carry task ids and titles — to any
+ * unauthenticated caller. The test suite was green the whole time, because
+ * nothing asserted anything about which routes actually call the auth helpers.
+ *
+ * So walk src/routes/api instead and require every route to reference a guard,
+ * or to be listed in PUBLIC_ROUTES with a written reason. A new unauthenticated
+ * API route now fails the build rather than waiting for someone to notice.
+ */
+
+const API_ROOT = path.resolve(__dirname, '../routes/api')
+
+/** Either guard is acceptable; requireLocalOrAuth also permits loopback. */
+const AUTH_GUARDS = ['isAuthenticated', 'requireLocalOrAuth']
+
+/**
+ * Routes that must stay reachable without a session, with the reason. Adding
+ * to this list is a deliberate act — that is the point of the list.
+ */
+const PUBLIC_ROUTES: Record<string, string> = {
+  'auth.ts': 'the login route itself — it mints the session',
+  'oauth.device-code.ts': 'OAuth device flow starts before a session exists',
+  'oauth.poll-token.ts': 'OAuth device flow polls before a session exists',
+}
+
+function walk(dir: string): Array<string> {
+  const out: Array<string> = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...walk(full))
+    } else if (entry.name.endsWith('.ts')) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+const routeFiles = walk(API_ROOT).map((full) => ({
+  rel: path.relative(API_ROOT, full),
+  text: fs.readFileSync(full, 'utf8'),
+}))
+
+describe('API route auth coverage', () => {
+  it('finds route files to check', () => {
+    expect(routeFiles.length).toBeGreaterThan(20)
+  })
+
+  it('every API route checks auth, or is an explicit public route', () => {
+    const offenders = routeFiles
+      .filter(({ rel }) => !(rel in PUBLIC_ROUTES))
+      .filter(({ text }) => !AUTH_GUARDS.some((guard) => text.includes(guard)))
+      .map(({ rel }) => rel)
+
+    expect(
+      offenders,
+      `These API routes have no auth guard. Add isAuthenticated()/requireLocalOrAuth(), ` +
+        `or add the file to PUBLIC_ROUTES with a reason:\n  ${offenders.join('\n  ')}`,
+    ).toEqual([])
+  })
+
+  it('the public-route allowlist has no stale entries', () => {
+    const present = new Set(routeFiles.map(({ rel }) => rel))
+    const stale = Object.keys(PUBLIC_ROUTES).filter((rel) => !present.has(rel))
+
+    expect(stale, `PUBLIC_ROUTES names files that no longer exist`).toEqual([])
+  })
+})

--- a/src/test/task-store.test.ts
+++ b/src/test/task-store.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('@/server/chat-event-bus', () => ({
   publishChatEvent: vi.fn(),
@@ -108,5 +108,50 @@ describe('task-store', () => {
   it('getTask() returns null for unknown id', async () => {
     const { getTask } = await getStore()
     expect(getTask('unknown')).toBeNull()
+  })
+
+  // ── Issue #8 Phase 2d ────────────────────────────────────────────────────
+
+  it('updateTask() can re-bind and unbind profileId', async () => {
+    const { createTask, updateTask } = await getStore()
+    const task = createTask({ title: 'Bound', profileId: 'alpha' })
+    expect(task.profileId).toBe('alpha')
+
+    // A task could previously only be bound at creation, so a mis-filed task
+    // was stuck in the wrong profile forever.
+    expect(updateTask(task.id, { profileId: 'beta' })?.profileId).toBe('beta')
+    expect(updateTask(task.id, { profileId: null })?.profileId).toBeNull()
+  })
+
+  it('updateTask() leaves profileId alone when it is not in the patch', async () => {
+    const { createTask, updateTask } = await getStore()
+    const task = createTask({ title: 'Bound', profileId: 'alpha' })
+    expect(updateTask(task.id, { title: 'Renamed' })?.profileId).toBe('alpha')
+  })
+
+  it('updateTaskOwner() reassigns a task whose owner is eligible', async () => {
+    const { createTask, updateTaskOwner } = await getStore()
+    // 'user' is the pre-identity placeholder the store still defaults to.
+    const task = createTask({ title: 'Orphan' })
+    expect(task.createdBy).toBe('user')
+
+    const moved = updateTaskOwner(task.id, 'alice', (owner) => owner === 'user')
+    expect(moved?.createdBy).toBe('alice')
+  })
+
+  it('updateTaskOwner() refuses a task that already belongs to a real user', async () => {
+    const { createTask, getTask, updateTaskOwner } = await getStore()
+    const task = createTask({ title: 'Owned', createdBy: 'bob' })
+
+    // Without the eligibility predicate the migration endpoint would be a way
+    // for a super admin to quietly take over another user's tasks.
+    const result = updateTaskOwner(task.id, 'alice', (owner) => owner === 'user')
+    expect(result).toBeNull()
+    expect(getTask(task.id)?.createdBy).toBe('bob')
+  })
+
+  it('updateTaskOwner() returns null for an unknown task', async () => {
+    const { updateTaskOwner } = await getStore()
+    expect(updateTaskOwner('nope', 'alice', () => true)).toBeNull()
   })
 })

--- a/src/test/task-store.test.ts
+++ b/src/test/task-store.test.ts
@@ -154,4 +154,35 @@ describe('task-store', () => {
     const { updateTaskOwner } = await getStore()
     expect(updateTaskOwner('nope', 'alice', () => true)).toBeNull()
   })
+
+  // canSeeTaskEvent() filters on createdBy, so the filter is only as good as
+  // the payloads task-store emits. Nothing else asserts on publishChatEvent —
+  // without this, task-store could stop sending createdBy and the SSE filter
+  // would silently starve, hiding every task event instead of the right ones.
+  it('create/move/delete publish task events carrying createdBy', async () => {
+    const { createTask, moveTask, deleteTask } = await getStore()
+    const { publishChatEvent } = await import('@/server/chat-event-bus')
+
+    const task = createTask({ title: 'Owned', createdBy: 'user-1' })
+    expect(publishChatEvent).toHaveBeenCalledWith(
+      'task.created',
+      expect.objectContaining({ taskId: task.id, createdBy: 'user-1' }),
+    )
+
+    moveTask(task.id, 'todo')
+    expect(publishChatEvent).toHaveBeenCalledWith(
+      'task.moved',
+      expect.objectContaining({
+        taskId: task.id,
+        column: 'todo',
+        createdBy: 'user-1',
+      }),
+    )
+
+    deleteTask(task.id)
+    expect(publishChatEvent).toHaveBeenCalledWith(
+      'task.deleted',
+      expect.objectContaining({ taskId: task.id, createdBy: 'user-1' }),
+    )
+  })
 })

--- a/src/test/user-profiles.test.ts
+++ b/src/test/user-profiles.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canAccessTask,
+  updateUserProfile,
+} from '../server/user-profiles'
+
+describe('canAccessTask() (Issue #8)', () => {
+  it('allows access in single-user mode (no userId)', () => {
+    expect(canAccessTask(null, { createdBy: 'someone' })).toBe(true)
+    expect(canAccessTask(undefined, { createdBy: 'someone' })).toBe(true)
+  })
+
+  it('allows a regular admin to access their own task', () => {
+    expect(canAccessTask('user-a', { createdBy: 'user-a' })).toBe(true)
+  })
+
+  it('denies a regular admin access to a foreign task', () => {
+    expect(canAccessTask('user-a', { createdBy: 'user-b' })).toBe(false)
+  })
+
+  it('denies a regular admin access to a task with no creator', () => {
+    expect(canAccessTask('user-a', {})).toBe(false)
+    expect(canAccessTask('user-a', { createdBy: null })).toBe(false)
+  })
+
+  it('allows a super admin to access any task', () => {
+    updateUserProfile('boss-user', { role: 'super_admin' })
+    expect(canAccessTask('boss-user', { createdBy: 'user-b' })).toBe(true)
+    expect(canAccessTask('boss-user', {})).toBe(true)
+  })
+})

--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -13,12 +13,15 @@ export interface HermesTask {
   column: TaskColumn
   priority: TaskPriority
   assignee: string | null
-  tags: string[]
+  tags: Array<string>
   dueDate: string | null
   position: number
   sourceType: TaskSourceType
   sourceId: string | null
   createdBy: string
+  /** Optional Hermes profile this task belongs to (Issue #8 Phase 2) —
+   *  regular admins see tasks of profiles bound to their account. */
+  profileId?: string | null
   createdAt: number
   updatedAt: number
 }
@@ -29,11 +32,12 @@ export interface CreateTaskInput {
   column?: TaskColumn
   priority?: TaskPriority
   assignee?: string | null
-  tags?: string[]
+  tags?: Array<string>
   dueDate?: string | null
   sourceType?: TaskSourceType
   sourceId?: string | null
   createdBy?: string
+  profileId?: string | null
 }
 
 export interface UpdateTaskInput {
@@ -42,12 +46,17 @@ export interface UpdateTaskInput {
   column?: TaskColumn
   priority?: TaskPriority
   assignee?: string | null
-  tags?: string[]
+  tags?: Array<string>
   dueDate?: string | null
   position?: number
+  /** Re-bind (or unbind, with null) the task's profile — Issue #8 Phase 2d.
+   *  A task could previously only be bound at creation, so a mis-filed task
+   *  was stuck in the wrong profile forever. The PATCH route validates the
+   *  caller can access the target profile, same rule as create. */
+  profileId?: string | null
 }
 
-export const TASK_COLUMNS: readonly TaskColumn[] = ['backlog', 'todo', 'in_progress', 'review', 'done'] as const
+export const TASK_COLUMNS: ReadonlyArray<TaskColumn> = ['backlog', 'todo', 'in_progress', 'review', 'done'] as const
 
 export const TASK_COLUMN_LABELS: Record<TaskColumn, string> = {
   backlog: 'Backlog',


### PR DESCRIPTION
## What

Makes the role-based task filtering from #8 Phase 1 actually reachable, closes the leaks it left open, and implements the profile-bound visibility the issue actually asks for. Closes #8.

This supersedes my own PR #22 (per-task access control on the by-id routes), which is a strict subset of this branch — happy to close #22 in favour of this, or to rebase this on top of it, whichever you prefer.

## Why Phase 1 could not work as shipped

`0f7d283` added the filter, and the filter is correct. It just cannot be reached:

- **There is no per-user identity.** Login is one shared password, and `src/routes/api/auth.ts` calls `storeSessionToken(token)` **without a userId**. So `getUserIdFromRequest()` always fell back to the process-wide `HERMES_USER_ID` env var — or to `undefined`, which skipped filtering entirely. Every session was the same anonymous "user".
- **There was no way to become a super_admin.** `updateUserProfile()` had zero HTTP callers, so promotion meant hand-editing Redis.

## 🔴 The part that is a live leak, not a feature gap

**`GET /api/events` had no auth check at all.** It subscribes with no session key, so it receives *everything* on the bus — including `task.created` / `task.moved` / `task.deleted`, which are published under the shared `'all'` key. It streamed every user's task ids and titles to **any unauthenticated caller**, and has done since the route was added.

Reproduced before the fix on an instance with `HERMES_PASSWORD` set:

```
curl -N http://localhost:3000/api/events     # no cookie
→ 200 text/event-stream   ... task.created {...}
```

After: `401`.

`/api/events/replay`, `/api/chat-events` (with no `sessionKey`) and `/api/audit?types=task.*` reached the same events by other routes. All four now require auth and filter with `canSeeTaskEvent()`. Legacy events with no `createdBy` are visible only to super admins.

## 🔴 The issue's literal ask was never implemented

> *Regular administrators should only see Kanban tasks that belong to profiles bound to their account*

Profile binding existed as data and was enforced **nowhere**. All six `/api/profiles/*` routes checked only `isAuthenticated`, and `getAccessibleProfiles()` had **no production callers at all** — it was referenced only from a test. So any authenticated regular admin could list, read, rename, delete and activate *every* profile in the install, while task-level filtering looked correct.

Now: `list` filters; `read`/`rename`/`delete`/`activate` return **404, not 403** (matching the task routes, so other accounts' profile names are not enumerable); and `create` binds the new profile to its creator, so a regular admin does not create a profile and immediately lose sight of it.

## What identity looks like

```bash
HERMES_USERS='alice:s3cret,bob:hunter2'   # split on the FIRST colon, so passwords may contain colons
HERMES_SUPER_ADMINS='alice'
```

Passwords compare with `timingSafeEqual`. Login threads a real `userId` into the session. The legacy shared-password login **deliberately leaves `userId` undefined** rather than pretending to be somebody — that path gets single-user behaviour, not a fake identity.

Multi-user mode now counts as password protection on its own: it exists to isolate users, so "no shared password ⇒ no auth" would have let anyone in with no identity at all.

## Two traps worth calling out in review

1. **`canAccessTask()` fails closed only in multi-user mode.** With `HERMES_USERS` unset, an identity-less request is allowed — that is the existing single-user behaviour and must not change for existing installs. With it set, an identity-less request is denied, because identity should always be present there and failing open would silently reopen the all-tasks leak.
2. **`getAccessibleProfiles()` returns `null`, not `[]`, for super admins.** `null` means *unrestricted*. The `[]` sentinel reads as "no access" to a naive caller and would invert the rule, hiding everything from the one account that is supposed to see all of it. Both branches are pinned by tests.

## Also included

- **Task re-binding.** Tasks carry an optional `profileId`, and `PATCH` can re-bind it under the same access rule as create. Without this a mis-filed task was stuck in its profile forever.
- **`/api/admin/users`** and **`/api/admin/orphan-tasks`**, both super_admin-only. The latter repairs tasks whose `createdBy` matches no configured username — including creators who have since left `HERMES_USERS` — which would otherwise be invisible to every regular admin permanently.
- **A "Users & Access" settings section**, because promoting a super admin was otherwise curl-only. It degrades to a plain explanation in single-user mode and for non-super-admins.
- `docs/MULTI_USER_ROADMAP.md` corrected: it claimed `/api/events` auth was "fixed in a separate branch". No such branch existed.

## Verification

- `vitest`: **190 → 217 passing**, none broken. The profile-visibility rules were **verified to fail when the check is reverted** — a guard that cannot fail is not a guard.
- `eslint`: **592 errors / 88 warnings vs `main`'s 622 / 88** — 30 fewer errors, no new ones.
- `tsc --noEmit`: **no new errors vs `main`.**
- Manual, two sessions, `HERMES_USERS='alice:a,bob:b'` + `HERMES_SUPER_ADMINS='alice'`: alice sees all tasks, bob only his own; `/api/events` with no cookie → 401; `/api/tasks/<alice-task>` as bob → 404; `/api/admin/users` as bob → 403.

This deliberately contains no i18n changes, so it does not conflict with any localization work.

Closes #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
