### PR TITLE
fix(events): require auth on the global /api/events SSE stream

### DIFF
--- a/src/routes/api/events.ts
+++ b/src/routes/api/events.ts
@@ -1,13 +1,30 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { isAuthenticated } from '../../server/auth-middleware'
 import {
   ensureBusStarted,
   subscribeToChatEvents,
 } from '../../server/chat-event-bus'
 
+/**
+ * Global SSE stream.
+ *
+ * This subscribes with no session key, so it receives every event on the bus —
+ * including task events, which task-store publishes under the shared 'all'
+ * session key with the task id and title in the payload. Without an auth check
+ * it streamed those to any unauthenticated caller. /api/chat-events,
+ * /api/events/replay and /api/audit all already guard; this one was missed.
+ */
 export const Route = createFileRoute('/api/events')({
   server: {
     handlers: {
-      GET: async () => {
+      GET: async ({ request }) => {
+        if (!isAuthenticated(request)) {
+          return new Response(
+            JSON.stringify({ ok: false, error: 'Unauthorized' }),
+            { status: 401, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+
         await ensureBusStarted()
 
         const encoder = new TextEncoder()

--- a/src/test/route-auth-coverage.test.ts
+++ b/src/test/route-auth-coverage.test.ts
@@ -1,0 +1,75 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Regression guard for the /api/events auth gap.
+ *
+ * /api/events shipped with no auth check at all, streaming every event on the
+ * bus — including task events, which carry task ids and titles — to any
+ * unauthenticated caller. The test suite was green the whole time, because
+ * nothing asserted anything about which routes actually call the auth helpers.
+ *
+ * So walk src/routes/api instead and require every route to reference a guard,
+ * or to be listed in PUBLIC_ROUTES with a written reason. A new unauthenticated
+ * API route now fails the build rather than waiting for someone to notice.
+ */
+
+const API_ROOT = path.resolve(__dirname, '../routes/api')
+
+/** Either guard is acceptable; requireLocalOrAuth also permits loopback. */
+const AUTH_GUARDS = ['isAuthenticated', 'requireLocalOrAuth']
+
+/**
+ * Routes that must stay reachable without a session, with the reason. Adding
+ * to this list is a deliberate act — that is the point of the list.
+ */
+const PUBLIC_ROUTES: Record<string, string> = {
+  'auth.ts': 'the login route itself — it mints the session',
+  'oauth.device-code.ts': 'OAuth device flow starts before a session exists',
+  'oauth.poll-token.ts': 'OAuth device flow polls before a session exists',
+}
+
+function walk(dir: string): Array<string> {
+  const out: Array<string> = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...walk(full))
+    } else if (entry.name.endsWith('.ts')) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+const routeFiles = walk(API_ROOT).map((full) => ({
+  rel: path.relative(API_ROOT, full),
+  text: fs.readFileSync(full, 'utf8'),
+}))
+
+describe('API route auth coverage', () => {
+  it('finds route files to check', () => {
+    expect(routeFiles.length).toBeGreaterThan(20)
+  })
+
+  it('every API route checks auth, or is an explicit public route', () => {
+    const offenders = routeFiles
+      .filter(({ rel }) => !(rel in PUBLIC_ROUTES))
+      .filter(({ text }) => !AUTH_GUARDS.some((guard) => text.includes(guard)))
+      .map(({ rel }) => rel)
+
+    expect(
+      offenders,
+      `These API routes have no auth guard. Add isAuthenticated()/requireLocalOrAuth(), ` +
+        `or add the file to PUBLIC_ROUTES with a reason:\n  ${offenders.join('\n  ')}`,
+    ).toEqual([])
+  })
+
+  it('the public-route allowlist has no stale entries', () => {
+    const present = new Set(routeFiles.map(({ rel }) => rel))
+    const stale = Object.keys(PUBLIC_ROUTES).filter((rel) => !present.has(rel))
+
+    expect(stale, `PUBLIC_ROUTES names files that no longer exist`).toEqual([])
+  })
+})


### PR DESCRIPTION
> **Relationship to #26 — please read first.**
>
> #26 (also mine) fixes this same leak as part of the full Issue #8 work, and its
> `events.ts` hunk is byte-identical to this one. It goes further: it adds the
> per-user task-event filter, which needs a real identity model, so it lands 29
> files including a new `user-credentials.ts`, an admin UI, and a regenerated
> `routeTree.gen.ts`.
>
> This PR is the **minimal standalone version**: 2 files, no new architecture,
> and a provable no-op on any install without `HERMES_PASSWORD` set. It exists so
> the unauthenticated-access half can land quickly without waiting on review of
> an identity system.
>
> **Merge whichever fits your appetite — not both.** If you take #26, close this
> one; the guard test is identical in both. If you'd rather take the small fix
> now and the identity model later, take this one and I'll rebase #26 on it.

---

## The problem

`GET /api/events` has no auth check at all. The handler doesn't even destructure `request`:

```ts
GET: async () => {
  await ensureBusStarted()
```

It then subscribes with **no session key**:

```ts
unsubscribe = subscribeToChatEvents((event) => { ... })
```

so `chat-event-bus.ts` forwards the entire bus to it. And `task-store.ts` publishes all three task events under the shared `'all'` session key, with the title in the payload:

```ts
publishChatEvent('task.created', { sessionKey: 'all', taskId: task.id, title: task.title, sourceType: task.sourceType })
```

Net effect: on a password-protected instance, anyone who can reach the port gets a live feed of every user's task activity, without logging in.

### Reproduced on this branch's base commit

Studio started with `HERMES_PASSWORD` set. One shell opens the stream with **no cookie**; another creates a task as a logged-in user:

```
$ curl -s -N http://localhost:3011/api/events        # no credentials at all
event: connected
data: {"ts":1786844995878}

event: task.created
data: {"sessionKey":"all","taskId":"05168eaf-...","title":"SECRET-ROADMAP-Q4-acquisition","sourceType":"manual"}
```

The title arrives in real time on an unauthenticated connection.

## The fix

Add the guard `/api/chat-events` already uses, verbatim — same 401 shape, same import ordering. `/api/events` is that route's structural twin (same `ReadableStream`/`TextEncoder`/keepalive skeleton), so this is the local idiom rather than a new one.

The check goes **before** `ensureBusStarted()`, so an unauthenticated request can't force bus startup.

Of the 81 files under `src/routes/api/`, `events.ts` was the only one lacking a guard that isn't deliberately public — `/api/chat-events`, `/api/events/replay` and `/api/audit` all already check. This one was simply missed.

## On a default install this is a no-op

`isAuthenticated()` returns `true` when `HERMES_PASSWORD` is unset (`auth-middleware.ts:161`), so nothing changes for the default deployment. Verified both ways on this branch:

| Setup | Request | Before | After |
|---|---|---|---|
| `HERMES_PASSWORD` set | no cookie | `200` + stream | `401` |
| `HERMES_PASSWORD` set | valid `hermes-auth` cookie | `200` | `200` |
| no `HERMES_PASSWORD` (default) | no cookie | `200` | `200` |

It only bites instances that opted into password protection — exactly the ones that believed this endpoint was already private.

**Blast radius:** one runtime consumer, `chat-screen.tsx`'s `new EventSource('/api/events')`. Same-origin, so the session cookie rides along automatically, and it can't mount unauthenticated anyway — `workspace-shell.tsx` renders `<LoginScreen />` first.

## The regression guard

The second commit adds `src/test/route-auth-coverage.test.ts`. This route shipped unguarded and the suite stayed green throughout, because nothing asserted which routes actually *call* the auth helpers. So the test walks `src/routes/api` and requires every route to reference `isAuthenticated`/`requireLocalOrAuth`, or to be in a `PUBLIC_ROUTES` allowlist with a written reason (`auth.ts` and the two `oauth.*` routes — all three genuinely pre-session).

Reverting the first commit turns it red:

```
AssertionError: These API routes have no auth guard...
- Expected:  []
+ Received:  [ "events.ts" ]
```

## Scope

`Refs #8` — deliberately not a closing keyword. This removes *unauthenticated* access. #8 is about *per-role visibility*, and even after #22 this stream still fans every authenticated user's task events to every other authenticated user. Closing #8 here would be inaccurate.

Complements #22 (by-id task authorization); no file overlap, mergeable in either order.

### Two things found while writing the guard, deliberately left out

Both are pre-existing and unrelated to this fix. Bundling them would turn an 18-line security fix into a red CI run demanding ~19 unrelated route changes, so I've left them for separate PRs — happy to open either:

1. **Four routes return the auth check as if it were a Response** — `hermes-config.ts:13`, `mcp/reload.ts:5`, `mcp/servers.ts:16` alias `isAuthenticated()` as `Response | true`, and `connection-status.ts:53` casts it. `isAuthenticated` returns a boolean, so an unauthenticated request gets a 500 rather than a 401.
2. **Fifteen mutating routes have no `requireJsonContentType()` (CSRF)** — including `POST /api/systemd-control`, `/api/start-hermes` and `/api/skills/install`. This matters most on default installs, where `isAuthenticated()` is always true.

## Verification

- `vitest run src/test/route-auth-coverage.test.ts` — fails on commit 1 reverted, passes with it. Demonstrated, not assumed.
- Full suite: 17 files, 193 tests passing.
- `tsc --noEmit` introduces no new errors. (The base commit has 4 pre-existing ones — two in `markdown.tsx` from the missing katex deps in #14, one in `sessions.ts` which is the `.data` shape from #18.)
- Runtime matrix above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

