### PR TITLE
fix(types): make version-compatibility typecheck

### DIFF
--- a/src/server/version-compatibility.ts
+++ b/src/server/version-compatibility.ts
@@ -23,7 +23,9 @@ const CACHE_TTL_MS = 60_000 // Cache version for 1 minute
  * Tries multiple endpoints for compatibility with different versions.
  */
 async function fetchVersionInfo(): Promise<VersionInfo | null> {
-  const authHeaders = BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
+  const authHeaders: Record<string, string> = BEARER_TOKEN
+    ? { Authorization: `Bearer ${BEARER_TOKEN}` }
+    : {}
 
   // Try different version endpoints for compatibility
   const endpoints = [


### PR DESCRIPTION
## What

A clean `tsc --noEmit` on `main` reports 4 errors. Three belong to open issues — two are the missing katex deps (#14, #11) and one is the session list shape (#18). This is the fourth, which belongs to no issue and no PR.

In `src/server/version-compatibility.ts`:

```ts
const authHeaders = BEARER_TOKEN ? { Authorization: `Bearer ${BEARER_TOKEN}` } : {}
```

TypeScript infers the union `{ Authorization: string } | { Authorization?: undefined }`. The second arm isn't assignable to `HeadersInit` (`Authorization?: undefined` violates the `Record<string, string>` index signature), so the `fetch()` call below matches neither overload.

Annotating the binding as `Record<string, string>` fixes it. Takes the baseline from **4 errors to 3**, and the remaining three are all already covered by open PRs.

## Two things worth flagging separately

I'm not fixing either of these here — they're judgement calls that belong to you, not scope for a type fix:

1. **This module is imported by nothing.** `getVersionInfo`, `checkVersionNow`, and `checkCompatibility` have no callers anywhere in `src/`. So the version-compat checking that landed in 356b3d5 isn't actually running. Either it's meant to be wired up somewhere and got missed, or it's dead and could go.

2. **`checkCompatibility()` conflates "outdated" with "incompatible."** It returns `compatible: warnings.length === 0`, so an agent that is merely *behind* the recommended 0.18 — but comfortably above the 0.8 minimum, and fully supported — is reported as incompatible. If the module does get wired up, that flag would misreport working setups. (Its one current use is a `console.log` whose condition `!compat.compatible || compat.warnings.length > 0` makes the flag redundant anyway, which is presumably why it went unnoticed.)

Happy to follow up on either if you tell me which way you want it to go.

## Verification

- `tsc --noEmit` → 4 errors before, 3 after.
- `vitest run` → 190 passed, unchanged.
- One-line-in-substance change, no behaviour touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)